### PR TITLE
add possibility for additional css/sass files

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,7 @@ pub struct Config {
     pub no_header: bool,
     pub readme_path: String,
     pub theme: Theme,
+    pub additional_css: String,
 }
 
 impl Config {
@@ -64,18 +65,20 @@ impl Config {
                     no_header: custom.no_header.unwrap_or(default.no_header),
                     readme_path: custom.readme_path.unwrap_or(default.readme_path),
                     theme: custom.theme.unwrap_or(default.theme),
+                    additional_css: custom.additional_css.unwrap_or(default.additional_css),
                 });
             // otherwise both oranda config and project manifest exists
             } else if let Some(project) = project {
                 // so return a merge of custom > project > default
                 return Ok(Config {
                     description: custom.description.unwrap_or(project.description),
-                    dist_dir: custom.dist_dir.unwrap_or(default.description),
+                    dist_dir: custom.dist_dir.unwrap_or(default.dist_dir),
                     homepage: Self::homepage(custom.homepage, project.homepage, default.homepage),
                     name: custom.name.unwrap_or(project.name),
                     no_header: custom.no_header.unwrap_or(default.no_header),
                     readme_path: custom.readme_path.unwrap_or(default.readme_path),
                     theme: custom.theme.unwrap_or(default.theme),
+                    additional_css: custom.additional_css.unwrap_or(default.additional_css),
                 });
             }
         }
@@ -102,13 +105,14 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            description: String::from("Queen triggerfish viperfish trench lightfish flying gurnard candlefish; Atlantic cod North American freshwater catfish four-eyed fish zebra lionfish worm eel."),
+            description: String::from(""),
             dist_dir: String::from("public"),
             homepage: None,
             name: String::from("My Axo project"),
             no_header: false,
             readme_path: String::from("README.md"),
             theme: Theme::Light,
+            additional_css: String::from(""),
         }
     }
 }

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -17,6 +17,7 @@ pub struct OrandaConfig {
     pub no_header: Option<bool>,
     pub readme_path: Option<String>,
     pub theme: Option<Theme>,
+    pub additional_css: Option<String>,
 }
 
 impl OrandaConfig {

--- a/src/site/css/_main.scss
+++ b/src/site/css/_main.scss
@@ -8,9 +8,7 @@ body,
   min-height: 100%;
   margin: 0;
   padding: 0;
-  color: var(--text);
-  
-  background-color: var(--bg);
+
   scroll-behavior: smooth;
 }
 
@@ -18,7 +16,9 @@ body {
   font-family: var(--sans-serif-font);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-
+  color: var(--text);
+  background-color: var(--bg);
+  
   .body {
     padding-top: 40px;
     padding-bottom: 60px;

--- a/src/site/fixtures/additional.css
+++ b/src/site/fixtures/additional.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/src/site/html/head.rs
+++ b/src/site/html/head.rs
@@ -5,7 +5,7 @@ pub fn head(config: &Config) -> String {
     format!(
         r#"
    <!DOCTYPE html>
-   <html lang="en">
+   <html lang="en" id="oranda">
    <head>
    
    <meta charset="utf-8" />
@@ -18,7 +18,7 @@ pub fn head(config: &Config) -> String {
     <meta property="og:url" content="{homepage}">
    </head>
    <body>
-   <div id="oranda"><div class="body {theme}"><div class="container">
+   <div><div class="body {theme}"><div class="container">
    "#,
         name = &config.name,
         description = &config.description,

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -70,6 +70,7 @@ fn config() -> Config {
     Config {
         description: String::from("description"),
         readme_path: String::from("./src/site/fixtures/readme.md"),
+        additional_css: String::from("./src/site/fixtures/additional.css"),
         theme: Theme::Dark,
         ..Default::default()
     }
@@ -96,4 +97,10 @@ fn reads_description() {
 fn reads_theme() {
     let site = Site::build(&config()).unwrap();
     assert!(site.html.contains("<div class=\"body dark\">"));
+}
+
+#[test]
+fn reads_additional_css() {
+    let site = Site::build(&config()).unwrap();
+    assert!(site.css.contains("#oranda body{background:red}"));
 }


### PR DESCRIPTION
Adds a new option called `additional_css` that you can use to pass a path to a local css or sass file and it will override our stuff

closes https://github.com/axodotdev/oranda/issues/13


related related https://github.com/axodotdev/oranda/issues/24