### PR TITLE
rename axo theme, make it default

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -1,5 +1,4 @@
 {
-  "theme": "axo",
   "homepage": "https://oranda.axo.dev",
   "repository": "https://github.com/axodotdev/oranda",
   "additional_pages": ["./docs/src/theme/themes.md"],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,7 +127,7 @@ impl Default for Config {
             name: String::from("My Axo project"),
             no_header: false,
             readme_path: String::from("README.md"),
-            theme: Theme::Light,
+            theme: Theme::AxoDark,
             remote_styles: vec![],
             additional_css: String::from(""),
             repository: None,

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -5,13 +5,14 @@ use serde::Deserialize;
 pub enum Theme {
     Light,
     Dark,
-    Axo,
+    #[serde(rename = "axo-dark")]
+    AxoDark,
 }
 
 pub fn css_class(theme: &Theme) -> &str {
     match theme {
         Theme::Dark => "dark",
-        Theme::Axo => "axo",
+        Theme::AxoDark => "axo-dark",
         _ => "light",
     }
 }

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -7,12 +7,15 @@ pub enum Theme {
     Dark,
     #[serde(rename = "axo-dark")]
     AxoDark,
+    #[serde(rename = "axo-light")]
+    AxoLight,
 }
 
 pub fn css_class(theme: &Theme) -> &str {
     match theme {
         Theme::Dark => "dark",
-        Theme::AxoDark => "axo-dark",
+        Theme::AxoDark => "axo dark",
+        Theme::AxoLight => "axo light",
         _ => "light",
     }
 }

--- a/src/site/css/stylesheets/_axo-dark.scss
+++ b/src/site/css/stylesheets/_axo-dark.scss
@@ -1,4 +1,4 @@
-.body.axo-dark {
+.body.axo.dark {
   --headings: #ff75c3;
   --text: #fafafa;
   --bg: #0f172a;

--- a/src/site/css/stylesheets/_axo-dark.scss
+++ b/src/site/css/stylesheets/_axo-dark.scss
@@ -1,4 +1,4 @@
-.body.axo {
+.body.axo-dark {
   --headings: #ff75c3;
   --text: #fafafa;
   --bg: #0f172a;

--- a/src/site/css/stylesheets/style.scss
+++ b/src/site/css/stylesheets/style.scss
@@ -25,5 +25,5 @@
 @import "main";
 @import "gh-corner";
 @import "dark";
-@import "axo";
+@import "axo-dark";
 @import "tabs";


### PR DESCRIPTION
- Renames `axo` theme to `axo-dark`
- Renames files and classes
- Makes theme default

closes https://github.com/axodotdev/oranda/issues/55