### PR TITLE
Read and sanitize raw html

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ammonia"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e6d1c7838db705c9b756557ee27c384ce695a1c51a6fe528784cb1c6840170"
+dependencies = [
+ "html5ever",
+ "maplit",
+ "once_cell",
+ "tendril",
+ "url",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +611,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,7 +728,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "once_cell",
- "phf",
+ "phf 0.9.0",
  "rand",
 ]
 
@@ -774,6 +797,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1064,6 +1101,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
 name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1328,7 @@ dependencies = [
 name = "oranda"
 version = "0.0.0"
 dependencies = [
+ "ammonia",
  "assert_cmd",
  "assert_fs",
  "axohtml",
@@ -1383,6 +1447,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,12 +1476,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b706f5936eb50ed880ae3009395b43ed19db5bff2ebd459c95e7bf013a89ab86"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.9.1",
  "phf_shared 0.9.0",
  "proc-macro-hack",
  "proc-macro2",
@@ -1885,6 +1978,19 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1993,6 +2099,17 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -2347,6 +2464,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "oranda"
 
 [dependencies]
 axohtml = "0.3.0"
+ammonia = "3"
 axum = "0.5.17"
 clap = { version = "4", features = ["derive", "help", "usage", "error-context", "wrap_help"] }
 comrak = "0.14"

--- a/src/site/css/stylesheets/_tacit.scss
+++ b/src/site/css/stylesheets/_tacit.scss
@@ -159,6 +159,7 @@ sup {
 }
 
 sub {
+  line-height: 1;
   bottom: -0.25em;
 }
 

--- a/src/site/markdown/mod.rs
+++ b/src/site/markdown/mod.rs
@@ -47,7 +47,7 @@ fn initialize_comrak_options() -> ComrakOptions {
 fn load(readme_path: &Path) -> Result<String> {
     if readme_path.exists() {
         let readme = fs::read_to_string(readme_path)?;
-        let safe_html = clean(&*readme);
+        let safe_html = clean(&readme);
         Ok(safe_html)
     } else {
         Err(OrandaError::FileNotFound {

--- a/src/site/markdown/mod.rs
+++ b/src/site/markdown/mod.rs
@@ -1,13 +1,13 @@
 pub mod syntax_highlight;
 
+use crate::errors::*;
+use crate::site::markdown::syntax_highlight::syntax_highlight;
+use ammonia::clean;
+use comrak::adapters::SyntaxHighlighterAdapter;
+use comrak::{self, ComrakOptions, ComrakPlugins};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-
-use crate::errors::*;
-use crate::site::markdown::syntax_highlight::syntax_highlight;
-use comrak::adapters::SyntaxHighlighterAdapter;
-use comrak::{self, ComrakOptions, ComrakPlugins};
 
 pub struct Adapters {}
 impl SyntaxHighlighterAdapter for Adapters {
@@ -39,6 +39,7 @@ fn initialize_comrak_options() -> ComrakOptions {
     options.extension.tasklist = true;
     options.extension.footnotes = true;
     options.extension.description_lists = true;
+    options.render.unsafe_ = true;
 
     options
 }
@@ -46,7 +47,8 @@ fn initialize_comrak_options() -> ComrakOptions {
 fn load(readme_path: &Path) -> Result<String> {
     if readme_path.exists() {
         let readme = fs::read_to_string(readme_path)?;
-        Ok(readme)
+        let safe_html = clean(&*readme);
+        Ok(safe_html)
     } else {
         Err(OrandaError::FileNotFound {
             filedesc: String::from("README"),


### PR DESCRIPTION
This PR fixes an issue where we were not reading raw HTML that was passed in the markdown. It also adds a [sanitization library](https://github.com/rust-ammonia/ammonia) for the same HTML to make sure nothing dangerous is passed.


As a sidenote, it seems all the things are rendered as `th` because `all-contributors` was not generating the tables right: https://github.github.com/gfm/#tables-extension-


Closes https://github.com/axodotdev/oranda/issues/58