### PR TITLE
Allow passing a config file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "axoasset"
 version = "0.1.0"
-source = "git+https://github.com/axodotdev/axoasset?branch=main#c3624c58c74e53397836713af11f8ad2bd4cb159"
+source = "git+https://github.com/axodotdev/axoasset?branch=main#72720d76e30c033ccf500bc4384e3b6e7ac529e3"
 dependencies = [
  "image",
  "mime",
@@ -198,6 +198,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bincode"
@@ -1613,7 +1619,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5329b8f106a176ab0dce4aae5da86bfcb139bb74fb00882859e03745011f3635"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "indexmap",
  "line-wrap",
  "quick-xml",
@@ -1835,11 +1841,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1872,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -1934,9 +1940,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1947,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2528,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
 
 [[package]]
 name = "unicode-ident"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # oranda
+
 > beautiful custom websites for your CLI
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # oranda
-
 > beautiful custom websites for your CLI
 
 ## Usage

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -10,11 +10,13 @@ use crate::site::Site;
 pub struct Build {
     #[arg(long, default_value = "./")]
     path: PathBuf,
+    #[arg(long, default_value = "./oranda.json")]
+    config: PathBuf,
 }
 
 impl Build {
     pub fn run(&self) -> Result<()> {
-        let config = Config::build()?;
+        let config = Config::build(&self.config)?;
         Site::write(&config)?;
         Ok(())
     }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -9,14 +9,14 @@ use crate::site::Site;
 #[derive(Debug, Parser)]
 pub struct Build {
     #[arg(long, default_value = "./")]
-    path: PathBuf,
+    project_root: PathBuf,
     #[arg(long, default_value = "./oranda.json")]
-    config: PathBuf,
+    config_path: PathBuf,
 }
 
 impl Build {
     pub fn run(&self) -> Result<()> {
-        let config = Config::build(&self.config)?;
+        let config = Config::build(&self.config_path)?;
         Site::write(&config)?;
         Ok(())
     }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use crate::config::Config;
 use crate::errors::*;
@@ -10,11 +11,13 @@ use tower_http::services::ServeDir;
 pub struct Serve {
     #[arg(long, default_value = "7979")]
     port: u16,
+    #[arg(long, default_value = "./oranda.json")]
+    config: PathBuf,
 }
 
 impl Serve {
     pub fn run(&self) -> Result<()> {
-        let config = Config::build()?;
+        let config = Config::build(&self.config)?;
         self.serve(config)?;
         Ok(())
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,7 @@ pub mod theme;
 use self::analytics::Analytics;
 use self::oranda::{OrandaConfig, Social};
 use crate::errors::*;
-use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxThemes;
+use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxTheme;
 use project::ProjectConfig;
 use std::path::Path;
 
@@ -23,7 +23,7 @@ pub struct Config {
     pub remote_styles: Vec<String>,
     pub additional_css: String,
     pub repository: Option<String>,
-    pub syntax_theme: SyntaxThemes,
+    pub syntax_theme: SyntaxTheme,
     pub analytics: Option<Analytics>,
     pub additional_pages: Option<Vec<String>>,
     pub social: Option<Social>,
@@ -143,7 +143,7 @@ impl Default for Config {
             remote_styles: vec![],
             additional_css: String::from(""),
             repository: None,
-            syntax_theme: SyntaxThemes::MaterialTheme,
+            syntax_theme: SyntaxTheme::MaterialTheme,
             analytics: None,
             additional_pages: None,
             social: None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@ use self::oranda::{OrandaConfig, Social};
 use crate::errors::*;
 use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxThemes;
 use project::ProjectConfig;
+use std::path::PathBuf;
 
 use theme::Theme;
 
@@ -31,7 +32,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn build() -> Result<Config> {
+    pub fn build(config_path: &PathBuf) -> Result<Config> {
         //Users can have multiple types of configuration or no configuration at all
         //
         //- Project configuration comes from a project manifest file. We currently
@@ -43,7 +44,7 @@ impl Config {
         //  you could use this file to override fields in your project manifest.
         //  This file can contain all possible public configuration fields.
         let default = Config::default();
-        let custom = OrandaConfig::load()?;
+        let custom = OrandaConfig::load(config_path)?;
         let project = ProjectConfig::load(None)?;
 
         // if there is no oranda.config file present...

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,7 @@ use self::oranda::{OrandaConfig, Social};
 use crate::errors::*;
 use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxThemes;
 use project::ProjectConfig;
-use std::path::PathBuf;
+use std::path::Path;
 
 use theme::Theme;
 
@@ -32,7 +32,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn build(config_path: &PathBuf) -> Result<Config> {
+    pub fn build(config_path: &Path) -> Result<Config> {
         //Users can have multiple types of configuration or no configuration at all
         //
         //- Project configuration comes from a project manifest file. We currently

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -36,12 +36,10 @@ pub struct OrandaConfig {
 
 impl OrandaConfig {
     pub fn load(config_path: &Path) -> Result<Option<OrandaConfig>> {
-        println!("reading from oranda config...");
         let config_future = axoasset::load_string(config_path.to_str().unwrap());
 
         let config = tokio::runtime::Handle::current().block_on(config_future)?;
         let data: OrandaConfig = serde_json::from_str(config.as_str())?;
-        println!("read data: {:?}", &data);
         Ok(Some(data))
     }
 }

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::path::Path;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -15,8 +14,6 @@ pub struct Social {
     pub image_alt: Option<String>,
     pub twitter_account: Option<String>,
 }
-
-static ORANDA_JSON: &str = "./oranda.json";
 
 #[derive(Debug, Deserialize)]
 pub struct OrandaConfig {

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
 use serde::Deserialize;
 
@@ -38,10 +39,10 @@ pub struct OrandaConfig {
 }
 
 impl OrandaConfig {
-    pub fn load() -> Result<Option<OrandaConfig>> {
+    pub fn load(config_path: &PathBuf) -> Result<Option<OrandaConfig>> {
         println!("reading from oranda config...");
-        if Path::new(ORANDA_JSON).exists() {
-            let oranda_json = fs::read_to_string(ORANDA_JSON)?;
+        if config_path.exists() {
+            let oranda_json = fs::read_to_string(config_path)?;
             println!("read json: {:?}", &oranda_json);
             let data: OrandaConfig = serde_json::from_str(&oranda_json)?;
             println!("read data: {:?}", &data);

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use crate::config::analytics::Analytics;
 use crate::config::theme::Theme;
 use crate::errors::*;
-use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxThemes;
+use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxTheme;
 
 #[derive(Debug, Deserialize)]
 pub struct Social {
@@ -26,7 +26,7 @@ pub struct OrandaConfig {
     pub remote_styles: Option<Vec<String>>,
     pub additional_css: Option<String>,
     pub repository: Option<String>,
-    pub syntax_theme: Option<SyntaxThemes>,
+    pub syntax_theme: Option<SyntaxTheme>,
     pub analytics: Option<Analytics>,
     pub additional_pages: Option<Vec<String>>,
     pub social: Option<Social>,

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use serde::Deserialize;
 
@@ -35,7 +35,7 @@ pub struct OrandaConfig {
 }
 
 impl OrandaConfig {
-    pub fn load(config_path: &PathBuf) -> Result<Option<OrandaConfig>> {
+    pub fn load(config_path: &Path) -> Result<Option<OrandaConfig>> {
         println!("reading from oranda config...");
         let config_future = axoasset::load_string(config_path.to_str().unwrap());
 

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -38,14 +37,11 @@ pub struct OrandaConfig {
 impl OrandaConfig {
     pub fn load(config_path: &PathBuf) -> Result<Option<OrandaConfig>> {
         println!("reading from oranda config...");
-        if config_path.exists() {
-            let oranda_json = fs::read_to_string(config_path)?;
-            println!("read json: {:?}", &oranda_json);
-            let data: OrandaConfig = serde_json::from_str(&oranda_json)?;
-            println!("read data: {:?}", &data);
-            Ok(Some(data))
-        } else {
-            Ok(None)
-        }
+        let config_future = axoasset::load_string(config_path.to_str().unwrap());
+
+        let config = tokio::runtime::Handle::current().block_on(config_future)?;
+        let data: OrandaConfig = serde_json::from_str(config.as_str())?;
+        println!("read data: {:?}", &data);
+        Ok(Some(data))
     }
 }

--- a/src/config/project/javascript.rs
+++ b/src/config/project/javascript.rs
@@ -1,12 +1,15 @@
-use std::fs;
+use crate::errors::*;
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]
 use assert_fs::fixture::{FileWriteStr, PathChild};
 
+#[cfg(test)]
 use crate::config::project::Type;
 use crate::config::ProjectConfig;
-use crate::errors::*;
+
+#[cfg(test)]
+use crate::initialize_tokio_runtime;
 
 static PACKAGE_JSON: &str = "./package.json";
 
@@ -56,6 +59,7 @@ fn it_detects_a_js_project() {
 
 #[test]
 fn it_loads_a_js_project_config() {
+    let _guard = initialize_tokio_runtime().enter();
     let tempdir = assert_fs::TempDir::new().expect("failed creating tempdir");
     let package_json = tempdir.child("package.json");
     package_json

--- a/src/config/project/javascript.rs
+++ b/src/config/project/javascript.rs
@@ -14,8 +14,9 @@ static PACKAGE_JSON: &str = "./package.json";
 pub struct JavaScript {}
 impl JavaScript {
     pub fn read(&self, project_root: &Option<PathBuf>) -> Result<ProjectConfig> {
-        println!("reading from package.json...");
-        let package_json = fs::read_to_string(JavaScript::config(project_root))?;
+        let path = JavaScript::config(project_root);
+        let package_json_future = axoasset::load_string(path.to_str().unwrap());
+        let package_json = tokio::runtime::Handle::current().block_on(package_json_future)?;
         let data: ProjectConfig = serde_json::from_str(&package_json)?;
         Ok(data)
     }

--- a/src/config/project/javascript.rs
+++ b/src/config/project/javascript.rs
@@ -1,3 +1,4 @@
+use crate::config::ProjectConfig;
 use crate::errors::*;
 use std::path::{Path, PathBuf};
 
@@ -6,7 +7,6 @@ use assert_fs::fixture::{FileWriteStr, PathChild};
 
 #[cfg(test)]
 use crate::config::project::Type;
-use crate::config::ProjectConfig;
 
 #[cfg(test)]
 use crate::initialize_tokio_runtime;

--- a/src/config/project/mod.rs
+++ b/src/config/project/mod.rs
@@ -30,13 +30,10 @@ impl ProjectConfig {
 
     fn detect(project_root: &Option<PathBuf>) -> Option<Type> {
         if Rust::config(project_root).exists() {
-            println!("detected rust project...");
             Some(Type::Rust(Rust {}))
         } else if JavaScript::config(project_root).exists() {
-            println!("detected javascript project...");
             Some(Type::JavaScript(JavaScript {}))
         } else {
-            println!("could not detect project type...");
             None
         }
     }

--- a/src/config/project/rust.rs
+++ b/src/config/project/rust.rs
@@ -1,6 +1,7 @@
-use std::path::{Path, PathBuf};
-
+use crate::config::ProjectConfig;
+use crate::errors::*;
 use serde::Deserialize;
+use std::path::{Path, PathBuf};
 
 #[cfg(test)]
 use crate::config::project::Type;
@@ -8,9 +9,6 @@ use crate::config::project::Type;
 use crate::initialize_tokio_runtime;
 #[cfg(test)]
 use assert_fs::fixture::{FileWriteStr, PathChild};
-
-use crate::config::ProjectConfig;
-use crate::errors::*;
 
 static CARGO_TOML: &str = "./Cargo.toml";
 

--- a/src/config/project/rust.rs
+++ b/src/config/project/rust.rs
@@ -21,8 +21,9 @@ struct CargoToml {
 pub struct Rust {}
 impl Rust {
     pub fn read(&self, project_root: &Option<PathBuf>) -> Result<ProjectConfig> {
-        println!("reading from cargo toml...");
-        let cargo_toml = fs::read_to_string(Rust::config(project_root))?;
+        let path = Rust::config(project_root);
+        let cargo_toml_future = axoasset::load_string(path.to_str().unwrap());
+        let cargo_toml = tokio::runtime::Handle::current().block_on(cargo_toml_future)?;
         let data: CargoToml = toml::from_str(&cargo_toml)?;
         Ok(data.package)
     }

--- a/src/config/project/rust.rs
+++ b/src/config/project/rust.rs
@@ -1,12 +1,14 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
 #[cfg(test)]
+use crate::config::project::Type;
+#[cfg(test)]
+use crate::initialize_tokio_runtime;
+#[cfg(test)]
 use assert_fs::fixture::{FileWriteStr, PathChild};
 
-use crate::config::project::Type;
 use crate::config::ProjectConfig;
 use crate::errors::*;
 
@@ -38,6 +40,7 @@ impl Rust {
 }
 
 #[test]
+
 fn it_detects_a_rust_project() {
     let tempdir = assert_fs::TempDir::new().expect("failed creating tempdir");
     let cargo_toml = tempdir.child("Cargo.toml");
@@ -62,6 +65,7 @@ description = ">o_o<"
 
 #[test]
 fn it_loads_a_rust_project_config() {
+    let _guard = initialize_tokio_runtime().enter();
     let tempdir = assert_fs::TempDir::new().expect("failed creating tempdir");
     let cargo_toml = tempdir.child("Cargo.toml");
     cargo_toml

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod site;
 
 use commands::{Build, Serve};
 use errors::*;
+use tokio::runtime::Runtime;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -19,6 +20,15 @@ struct Cli {
 enum Command {
     Build(Build),
     Serve(Serve),
+}
+
+pub fn initialize_tokio_runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .max_blocking_threads(128)
+        .enable_all()
+        .build()
+        .expect("Initializing tokio runtime failed")
 }
 
 fn main() -> Result<()> {

--- a/src/site/markdown/mod.rs
+++ b/src/site/markdown/mod.rs
@@ -9,10 +9,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use self::syntax_highlight::syntax_themes::SyntaxThemes;
+use self::syntax_highlight::syntax_themes::SyntaxTheme;
 
 pub struct Adapters<'a> {
-    syntax_theme: &'a SyntaxThemes,
+    syntax_theme: &'a SyntaxTheme,
 }
 impl SyntaxHighlighterAdapter for Adapters<'_> {
     fn highlight(&self, lang: Option<&str>, code: &str) -> String {
@@ -60,7 +60,7 @@ fn load(readme_path: &Path) -> Result<String> {
     }
 }
 
-pub fn body(readme_path: &Path, syntax_theme: &SyntaxThemes) -> Result<String> {
+pub fn body(readme_path: &Path, syntax_theme: &SyntaxTheme) -> Result<String> {
     let readme = load(readme_path)?;
     let options = initialize_comrak_options();
 

--- a/src/site/markdown/mod.rs
+++ b/src/site/markdown/mod.rs
@@ -9,10 +9,14 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-pub struct Adapters {}
-impl SyntaxHighlighterAdapter for Adapters {
+use self::syntax_highlight::syntax_themes::SyntaxThemes;
+
+pub struct Adapters<'a> {
+    syntax_theme: &'a SyntaxThemes,
+}
+impl SyntaxHighlighterAdapter for Adapters<'_> {
     fn highlight(&self, lang: Option<&str>, code: &str) -> String {
-        let highlighted_code = syntax_highlight(lang, code);
+        let highlighted_code = syntax_highlight(lang, code, self.syntax_theme);
 
         // requires a string to be returned
         match highlighted_code {
@@ -56,12 +60,14 @@ fn load(readme_path: &Path) -> Result<String> {
     }
 }
 
-pub fn body(readme_path: &Path) -> Result<String> {
+pub fn body(readme_path: &Path, syntax_theme: &SyntaxThemes) -> Result<String> {
     let readme = load(readme_path)?;
     let options = initialize_comrak_options();
 
     let mut plugins = ComrakPlugins::default();
-    let adapter = Adapters {};
+    let adapter = Adapters {
+        syntax_theme: syntax_theme,
+    };
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
     let unsafe_html = comrak::markdown_to_html_with_plugins(&readme, &options, &plugins);

--- a/src/site/markdown/mod.rs
+++ b/src/site/markdown/mod.rs
@@ -65,9 +65,7 @@ pub fn body(readme_path: &Path, syntax_theme: &SyntaxThemes) -> Result<String> {
     let options = initialize_comrak_options();
 
     let mut plugins = ComrakPlugins::default();
-    let adapter = Adapters {
-        syntax_theme: syntax_theme,
-    };
+    let adapter = Adapters { syntax_theme };
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
     let unsafe_html = comrak::markdown_to_html_with_plugins(&readme, &options, &plugins);

--- a/src/site/markdown/mod.rs
+++ b/src/site/markdown/mod.rs
@@ -70,7 +70,7 @@ pub fn body(readme_path: &Path, syntax_theme: &SyntaxThemes) -> Result<String> {
 
     let unsafe_html = comrak::markdown_to_html_with_plugins(&readme, &options, &plugins);
     let safe_html = Builder::new()
-        .add_generic_attributes(&["style"])
+        .add_generic_attributes(&["style", "class", "id"])
         .clean(&unsafe_html)
         .to_string();
     Ok(safe_html)

--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -1,7 +1,7 @@
 pub mod syntax_themes;
 
 use crate::errors::*;
-use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxThemes;
+use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxTheme;
 use syntect::highlighting::ThemeSet;
 use syntect::html::highlighted_html_for_string;
 use syntect::parsing::{SyntaxReference, SyntaxSet};
@@ -30,7 +30,7 @@ fn find_syntax<'a>(ps: &'a SyntaxSet, language: &'a str) -> Result<&'a SyntaxRef
 pub fn syntax_highlight(
     lang: Option<&str>,
     code: &str,
-    syntax_theme: &SyntaxThemes,
+    syntax_theme: &SyntaxTheme,
 ) -> Result<String> {
     let ps = SyntaxSet::load_defaults_newlines();
     let theme_set =
@@ -54,7 +54,7 @@ fn creates_syntax() {
     let highlight = syntax_highlight(
         Some("js"),
         "console.log(5)",
-        &SyntaxThemes::AgilaClassicOceanicNext,
+        &SyntaxTheme::AgilaClassicOceanicNext,
     )
     .unwrap();
 

--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -51,11 +51,12 @@ pub fn syntax_highlight(
 
 #[test]
 fn creates_syntax() {
-    assert!(syntax_highlight(
+    let highlight = syntax_highlight(
         Some("js"),
         "console.log(5)",
-        &SyntaxThemes::AgilaClassicOceanicNext
+        &SyntaxThemes::AgilaClassicOceanicNext,
     )
-    .unwrap()
-    .contains("<span style=\"color:#ffcb6b;\">console</span>"));
+    .unwrap();
+
+    assert!(highlight.contains("<span style=\"color:#fac863;\">console</span>"));
 }

--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -28,8 +28,11 @@ fn find_syntax<'a>(ps: &'a SyntaxSet, language: &'a str) -> Result<&'a SyntaxRef
     ))
 }
 
-pub fn syntax_highlight(lang: Option<&str>, code: &str) -> Result<String> {
-    let config = Config::build()?;
+pub fn syntax_highlight(
+    lang: Option<&str>,
+    code: &str,
+    syntax_theme: &SyntaxThemes,
+) -> Result<String> {
     let ps = SyntaxSet::load_defaults_newlines();
     let theme_set =
         ThemeSet::load_from_folder("src/site/markdown/syntax_highlight/syntax_themes").unwrap();
@@ -43,13 +46,17 @@ pub fn syntax_highlight(lang: Option<&str>, code: &str) -> Result<String> {
         code,
         &ps,
         syntax,
-        &theme_set.themes[&SyntaxThemes::as_str(&config.syntax_theme)],
+        &theme_set.themes[&syntax_theme.as_str()],
     )?)
 }
 
 #[test]
 fn creates_syntax() {
-    assert!(syntax_highlight(Some("js"), "console.log(5)")
-        .unwrap()
-        .contains("<span style=\"color:#ffcb6b;\">console</span>"));
+    assert!(syntax_highlight(
+        Some("js"),
+        "console.log(5)",
+        &SyntaxThemes::AgilaClassicOceanicNext
+    )
+    .unwrap()
+    .contains("<span style=\"color:#ffcb6b;\">console</span>"));
 }

--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -1,6 +1,5 @@
 pub mod syntax_themes;
 
-use crate::config::Config;
 use crate::errors::*;
 use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxThemes;
 use syntect::highlighting::ThemeSet;

--- a/src/site/markdown/syntax_highlight/syntax_themes.rs
+++ b/src/site/markdown/syntax_highlight/syntax_themes.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 #[derive(Debug, Deserialize)]
-pub enum SyntaxThemes {
+pub enum SyntaxTheme {
     AgilaClassicOceanicNext,
     AgilaCobalt,
     AgilaLightSolarized,
@@ -23,7 +23,7 @@ pub enum SyntaxThemes {
     OneDark,
 }
 
-impl SyntaxThemes {
+impl SyntaxTheme {
     pub fn as_str(&self) -> String {
         format!("{:?}", &self)
     }

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -30,7 +30,7 @@ impl Site {
         let dist = &config.dist_dir;
         std::fs::create_dir_all(dist)?;
         let readme_path = Path::new(&file_path);
-        let content = markdown::body(readme_path)?;
+        let content = markdown::body(readme_path, &config.syntax_theme)?;
         let html = html::build(config, content)?;
         let css = Self::css(config)?;
 


### PR DESCRIPTION
This PR allows the user to pass a path to a config file if they don't wish to use `oranda.json`


closes https://github.com/axodotdev/oranda/issues/49

closes https://github.com/axodotdev/oranda/issues/70

closes https://github.com/axodotdev/oranda/issues/78