### PR TITLE
Bump oranda version

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -74,6 +74,12 @@ Don't forget that Markdown also accepts raw html (as we can see in the last few 
 
 <div class="title">For instance, this is a plain div with a class attached to style it in the title style.<sup>Wow.</sup></div>
 
+You can also have things in your markdown that will not show on oranda by adding the class `oranda-hide`.
+
+<div class="oranda-hide">
+    you can't see this
+</div>
+
 ## Nesting
 
 ### Lists

--- a/src/site/css/mod.rs
+++ b/src/site/css/mod.rs
@@ -28,7 +28,7 @@ fn concat_minify_css(css_links: Vec<String>) -> Result<String> {
 // https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+redundant_allocation+sort%3Aupdated-desc
 #[allow(clippy::vec_box)]
 pub fn fetch_fringe_css(config: &Config) -> Result<Box<link<String>>> {
-    const FRINGE_VERSION: &str = "0.0.7";
+    const FRINGE_VERSION: &str = "0.0.8";
     let fringe_href = format!(
         "https://www.unpkg.com/@axodotdev/fringe@{}/themes/",
         FRINGE_VERSION


### PR DESCRIPTION
- Bumps oranda version
- Adds `oranda-hide` example

related https://github.com/axodotdev/turbo-axo/pull/190/