### PR TITLE
More properly read in package.json files, kinda

### DIFF
--- a/src/config/project/javascript.rs
+++ b/src/config/project/javascript.rs
@@ -1,8 +1,48 @@
+use serde::Deserialize;
+
 use crate::config::ProjectConfig;
 use crate::errors::*;
 use std::path::{Path, PathBuf};
 
 static PACKAGE_JSON: &str = "./package.json";
+
+/// A package.json file
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub struct PackageJson {
+    /// Name of the package
+    pub name: String,
+    /// Version of the package
+    pub version: Option<String>,
+    /// Description of the package
+    pub description: String,
+    /// Link to the homepage
+    pub homepage: Option<String>,
+    /// Link to the repository
+    pub repository: Option<Repository>,
+    /// License of the package
+    pub license: Option<String>,
+}
+
+/// A link to a repository
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum Repository {
+    /// Shorthand syntax
+    Short(String),
+    /// Long form
+    Long(LongRepository),
+}
+
+/// A link to a repository
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub struct LongRepository {
+    /// The type of link it is
+    pub r#type: String,
+    /// The url
+    pub url: String,
+    /// The subdirectory to find the project at
+    pub directory: Option<String>,
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct JavaScript {}
@@ -11,8 +51,32 @@ impl JavaScript {
         let path = JavaScript::config(project_root);
         let package_json_future = axoasset::load_string(path.to_str().unwrap());
         let package_json = tokio::runtime::Handle::current().block_on(package_json_future)?;
-        let data: ProjectConfig = serde_json::from_str(&package_json)?;
-        Ok(data)
+        let data: PackageJson = serde_json::from_str(&package_json)?;
+
+        let repository = data.repository.map(|repo| match repo {
+            // TODO: process this into a proper URL?
+            //
+            // It can be things like:
+            //
+            // * "npm/npm"
+            // * "github:user/repo"
+            // * "gist:11081aaa281"
+            // * "bitbucket:user/repo"
+            // * "gitlab:user/repo"
+            //
+            // Using the same syntax as https://docs.npmjs.com/cli/v7/commands/npm-install
+            Repository::Short(repo) => repo,
+            Repository::Long(repo) => repo.url,
+        });
+
+        Ok(ProjectConfig {
+            name: data.name,
+            description: data.description,
+            homepage: data.homepage,
+            repository,
+            version: data.version,
+            license: data.license,
+        })
     }
 
     pub fn config(project_root: &Option<PathBuf>) -> PathBuf {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -63,6 +63,7 @@ fn it_loads_a_js_project_config() {
             r#"
 {
     "name": "axo",
+    "version": "0.1.0",
     "description": ">o_o<"
 }
     "#,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -64,7 +64,11 @@ fn it_loads_a_js_project_config() {
 {
     "name": "axo",
     "version": "0.1.0",
-    "description": ">o_o<"
+    "description": ">o_o<",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/axodotdev/not-a-real-project"
+    }
 }
     "#,
         )


### PR DESCRIPTION
~~We can defer to a proper library for the definitions~~ We can write out own definitions and just pull out the parts we want *but* the repository field is just super whack and complex so it's probably not a URL. If you have some npm project that you Definitely Want To Work I can roll up my sleeves and actually iterate on the behaviour.

Fixes #120 