### PR TITLE
Quick docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ using `cargo-dist` you can add this to your `oranda.json`:
 
 ```json
 "artifacts": {
-    "cargo-dist": true
+    "cargo_dist": true
 }
 ```
 


### PR DESCRIPTION
Uses `cargo_dist` instead of `cargo-dist`

closes https://github.com/axodotdev/oranda/issues/139