### PR TITLE
Better install page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,9 +297,9 @@ checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc97d812f7dfef5211f9c87a4a88d1dcecadd7d5fe230537404668e4a5c36fb5"
+checksum = "9abefb2f6a96d862286725aa15c5b6167f07430aef9ca35858061672beac2ac1"
 dependencies = [
  "camino",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ minifier = "0.2.2"
 axohtml = "0.4.1"
 ammonia = "3"
 linked-hash-map = {version="0.5.6", features=["serde_impl"]}
-cargo-dist-schema = "0.0.1"
+cargo-dist-schema = "0.0.2"
 lazy_static = "1.4.0"
 axum = "0.6.2"
 clap = { version = "4", features = ["derive", "help", "usage", "error-context", "wrap_help"] }

--- a/oranda.json
+++ b/oranda.json
@@ -1,6 +1,6 @@
 {
   "favicon": "https://www.axo.dev/favicon.ico",
-  "path_prefix": "oranda",
+
   "additional_pages": [
     "./docs/configuration.md",
     "./docs/themes.md",

--- a/oranda.json
+++ b/oranda.json
@@ -1,6 +1,6 @@
 {
   "favicon": "https://www.axo.dev/favicon.ico",
-
+  "path_prefix": "oranda",
   "additional_pages": [
     "./docs/configuration.md",
     "./docs/themes.md",

--- a/src/site/artifacts/cargo_dist.rs
+++ b/src/site/artifacts/cargo_dist.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::site::link;
 use crate::site::markdown::{syntax_highlight, SyntaxTheme};
-use axohtml::elements::{div, li, span};
+use axohtml::elements::{div, span};
 use axohtml::{html, text, unsafe_text};
 use cargo_dist_schema::{Artifact, ArtifactKind, DistManifest};
 
@@ -168,7 +168,7 @@ fn create_table_content(table: Vec<Box<span<String>>>) -> Box<div<String>> {
 // False positive duplicate allocation warning
 // https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+redundant_allocation+sort%3Aupdated-desc
 #[allow(clippy::vec_box)]
-pub fn build_list(manifest: &DistManifest, syntax_theme: &SyntaxTheme) -> Vec<Box<li<String>>> {
+pub fn build_list(manifest: &DistManifest, syntax_theme: &SyntaxTheme) -> Box<div<String>> {
     let mut list = vec![];
     for release in manifest.releases.iter() {
         for artifact in release.artifacts.iter() {
@@ -179,9 +179,13 @@ pub fn build_list(manifest: &DistManifest, syntax_theme: &SyntaxTheme) -> Vec<Bo
                 }
                 let install_code =
                     get_install_hint(&release.artifacts, &artifact.target_triples, syntax_theme);
+                let detect_text = match get_os(targets.as_str()) {
+                    Some(os) => os,
+                    None => targets.as_str(),
+                };
                 list.extend(html!(
                     <li class="list-none">
-                        <h5>{text!(targets)}</h5>
+                        <h5 class="capitalize">{text!(detect_text)}</h5>
                         {unsafe_text!(install_code)}
                     </li>
                 ))
@@ -189,5 +193,12 @@ pub fn build_list(manifest: &DistManifest, syntax_theme: &SyntaxTheme) -> Vec<Bo
         }
     }
 
-    list
+    html!(
+    <div>
+        <h3>{text!("Install via script")}</h3>
+        <ul>
+            {list}
+        </ul>
+    </div>
+    )
 }

--- a/src/site/artifacts/cargo_dist.rs
+++ b/src/site/artifacts/cargo_dist.rs
@@ -124,16 +124,17 @@ pub fn build_table(manifest: DistManifest, config: &Config) -> Box<div<String>> 
     let mut table = vec![];
     for release in manifest.releases.iter() {
         for artifact in release.artifacts.iter() {
-            let name = &artifact.name;
-            let url = create_download_link(config, name);
-            let kind = get_kind_string(&artifact.kind);
-            let targets: &String = &artifact.target_triples.clone().into_iter().collect();
-            table.extend(vec![
-                html!(<span>{text!(name)}</span>),
-                html!(<span>{text!(kind)}</span>),
-                html!(<span>{text!(targets)}</span>),
-                html!(<span><a href=url>{text!("Download")}</a></span>),
-            ]);
+            if let Some(name) = artifact.name.clone() {
+                let url = create_download_link(config, &name);
+                let kind = get_kind_string(&artifact.kind);
+                let targets: &String = &artifact.target_triples.clone().into_iter().collect();
+                table.extend(vec![
+                    html!(<span>{text!(name)}</span>),
+                    html!(<span>{text!(kind)}</span>),
+                    html!(<span>{text!(targets)}</span>),
+                    html!(<span><a href=url>{text!("Download")}</a></span>),
+                ]);
+            }
         }
     }
 
@@ -179,13 +180,17 @@ pub fn build_list(manifest: &DistManifest, syntax_theme: &SyntaxTheme) -> Box<di
                 }
                 let install_code =
                     get_install_hint(&release.artifacts, &artifact.target_triples, syntax_theme);
-                let detect_text = match get_os(targets.as_str()) {
-                    Some(os) => os,
-                    None => targets.as_str(),
+
+                let title = match artifact.description.clone() {
+                    Some(desc) => desc,
+                    None => match get_os(targets.as_str()) {
+                        Some(os) => String::from(os),
+                        None => targets,
+                    },
                 };
                 list.extend(html!(
                     <li class="list-none">
-                        <h5 class="capitalize">{text!(detect_text)}</h5>
+                        <h5 class="capitalize">{text!(title)}</h5>
                         {unsafe_text!(install_code)}
                     </li>
                 ))

--- a/src/site/artifacts/package_managers.rs
+++ b/src/site/artifacts/package_managers.rs
@@ -3,7 +3,7 @@ use crate::errors::*;
 use crate::site::markdown::{syntax_highlight, SyntaxTheme};
 use linked_hash_map::LinkedHashMap;
 
-use axohtml::elements::{div, li};
+use axohtml::elements::div;
 use axohtml::{html, text, unsafe_text};
 
 fn create_package_install_code(code: &str, syntax_theme: &SyntaxTheme) -> String {
@@ -17,16 +17,20 @@ fn create_package_install_code(code: &str, syntax_theme: &SyntaxTheme) -> String
 // False positive duplicate allocation warning
 // https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+redundant_allocation+sort%3Aupdated-desc
 #[allow(clippy::vec_box)]
-pub fn build_list(
-    managers: &LinkedHashMap<String, String>,
-    config: &Config,
-) -> Vec<Box<li<String>>> {
+pub fn build_list(managers: &LinkedHashMap<String, String>, config: &Config) -> Box<div<String>> {
     let mut list = vec![];
     for (manager, install_code) in managers.iter() {
         list.extend(html!(<li class="list-none"><h5>{text!(manager)}</h5> {unsafe_text!(create_package_install_code(install_code, &config.syntax_theme))}</li>))
     }
 
-    list
+    html!(
+    <div>
+        <h3>{text!("Install via package manager")}</h3>
+        <ul>
+            {list}
+        </ul>
+    </div>
+    )
 }
 
 pub fn build(

--- a/src/site/artifacts/page.rs
+++ b/src/site/artifacts/page.rs
@@ -3,34 +3,33 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::site::artifacts::cargo_dist;
 use crate::site::artifacts::package_managers;
-use axohtml::{html, text};
+use axohtml::html;
 
 pub fn build(config: &Config) -> Result<String> {
     let mut html = vec![];
     let manifest = cargo_dist::fetch_manifest(config)?;
 
-    if let Some(Artifacts {
-        package_managers: Some(managers),
-        ..
-    }) = &config.artifacts
-    {
-        let mut list = vec![];
+    if config.artifacts.is_some() {
+        let mut lists = vec![];
         if let Some(Artifacts {
             cargo_dist: Some(true),
             ..
         }) = &config.artifacts
         {
-            list.extend(cargo_dist::build_list(&manifest, &config.syntax_theme));
+            lists.extend(cargo_dist::build_list(&manifest, &config.syntax_theme));
         }
 
-        list.extend(package_managers::build_list(managers, config));
+        if let Some(Artifacts {
+            package_managers: Some(managers),
+            ..
+        }) = &config.artifacts
+        {
+            lists.extend(package_managers::build_list(managers, config));
+        }
 
         html.extend(html!(
             <div class="package-managers-downloads">
-                <h3>{text!("Install methods")}</h3>
-                <ul>
-                    {list}
-                </ul>
+                {lists}
             </div>
         ));
     };


### PR DESCRIPTION
- Always shows the install section
- Divides script and package manager installs
- gives os's better names

![localhost_3000_artifacts (1)](https://user-images.githubusercontent.com/1051509/217548205-66bfc8b7-b7a7-4694-b037-c2ea7b44c1d7.png)

closes https://github.com/axodotdev/oranda/issues/163