### PR TITLE
Add copy & source to install page

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -1,6 +1,6 @@
 {
   "favicon": "https://www.axo.dev/favicon.ico",
-  
+  "path_prefix": "oranda",
   "additional_pages": [
     "./docs/configuration.md",
     "./docs/themes.md",

--- a/oranda.json
+++ b/oranda.json
@@ -1,6 +1,6 @@
 {
   "favicon": "https://www.axo.dev/favicon.ico",
-  "path_prefix": "oranda",
+  
   "additional_pages": [
     "./docs/configuration.md",
     "./docs/themes.md",

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -74,7 +74,7 @@ impl Serve {
                     format!("Unhandled internal error: {}", error),
                 )
             });
-        const FRINGE_VERSION: &str = "0.0.9";
+        const FRINGE_VERSION: &str = "0.0.10";
         let prefix_route = format!("/{}", prefix);
         let fringe_route = format!("/{}/fringe@{}.css", prefix, FRINGE_VERSION);
         let app = Router::new().nest_service(&prefix_route, serve_dir).route(

--- a/src/site/artifacts/cargo_dist.rs
+++ b/src/site/artifacts/cargo_dist.rs
@@ -6,7 +6,7 @@ use axohtml::elements::{div, span};
 use axohtml::{html, text, unsafe_text};
 use cargo_dist_schema::{Artifact, ArtifactKind, DistManifest, Release};
 
-use crate::site::artifacts::get_copy_logo;
+use crate::site::artifacts::get_copyicon;
 
 pub fn get_os(name: &str) -> Option<&str> {
     match name.trim() {
@@ -109,7 +109,7 @@ fn build_install_block(
 ) -> Result<Box<div<String>>> {
     let install_code = get_install_hint_code(&release.artifacts, &artifact.target_triples, config)?;
 
-    let copy_icon = get_copy_logo();
+    let copy_icon = get_copyicon();
     let hint = get_install_hint(&release.artifacts, &artifact.target_triples, config)?;
 
     Ok(html!(

--- a/src/site/artifacts/cargo_dist.rs
+++ b/src/site/artifacts/cargo_dist.rs
@@ -2,10 +2,11 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::site::markdown::syntax_highlight;
 use crate::site::{link, Site};
-use axohtml::dom::UnsafeTextNode;
 use axohtml::elements::{div, span};
 use axohtml::{html, text, unsafe_text};
-use cargo_dist_schema::{Artifact, ArtifactKind, DistManifest};
+use cargo_dist_schema::{Artifact, ArtifactKind, DistManifest, Release};
+
+use super::get_copy_logo;
 
 pub fn get_os(name: &str) -> Option<&str> {
     match name.trim() {
@@ -101,6 +102,31 @@ fn create_download_link(config: &Config, name: &String) -> String {
     }
 }
 
+fn build_install_block(
+    config: &Config,
+    release: &Release,
+    artifact: &Artifact,
+) -> Result<Box<div<String>>> {
+    let install_code = get_install_hint_code(&release.artifacts, &artifact.target_triples, config)?;
+
+    let copy_icon = get_copy_logo();
+    let hint = get_install_hint(&release.artifacts, &artifact.target_triples, config)?;
+
+    Ok(html!(
+        <div class="install-code-wrapper">
+            {unsafe_text!(install_code)}
+            <button
+                data-copy={hint.0}
+                class="business-button primary copy-clipboard-button button">
+                {copy_icon}
+            </button>
+            <a class="business-button primary button" href=(hint.1)>
+                {text!("Source")}
+            </a>
+        </div>
+    ))
+}
+
 pub fn build(config: &Config) -> Result<Box<div<String>>> {
     if config.repository.is_none() || config.version.is_none() {
         return Err(OrandaError::Other(String::from(
@@ -118,27 +144,16 @@ pub fn build(config: &Config) -> Result<Box<div<String>>> {
                 for targ in artifact.target_triples.iter() {
                     targets.push_str(format!("{} ", targ).as_str());
                 }
-                let install_code =
-                    get_install_hint_code(&release.artifacts, &artifact.target_triples, config)?;
                 let detect_text = match get_os(targets.as_str()) {
                     Some(os) => format!("We have detected you are on {}, are we wrong?", os),
                     None => String::from("We couldn't detect the system you are using."),
                 };
-
-                // axohtml does not support SVG for now
-                let copy_icon:  Box<UnsafeTextNode<String>> = unsafe_text!("<svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>");
-                let hint = get_install_hint(&release.artifacts, &artifact.target_triples, config)?;
+                let install_code_block = build_install_block(config, release, artifact);
 
                 html.extend(html!(
                     <div class="hidden target artifact-header" data-targets=&targets>
                         <h4 class="text-center">{text!("Install")}</h4>
-                        <div class="install-code-wrapper">
-                            {unsafe_text!(install_code)}
-                            <button data-copy={hint.0} class="business-button primary copy-clipboard-button button">{copy_icon}</button>
-                            <a class="business-button primary button" href=(hint.1)>
-                                {text!("Source")}
-                            </a>
-                        </div>
+                        {install_code_block}
                         <div>
                             <span class="text-center detect">
                                 {text!(detect_text)}
@@ -217,8 +232,6 @@ pub fn build_list(manifest: &DistManifest, config: &Config) -> Result<Box<div<St
                 for targ in artifact.target_triples.iter() {
                     targets.push_str(format!("{} ", targ).as_str());
                 }
-                let install_code =
-                    get_install_hint_code(&release.artifacts, &artifact.target_triples, config)?;
 
                 let title = match artifact.description.clone() {
                     Some(desc) => desc,
@@ -227,10 +240,11 @@ pub fn build_list(manifest: &DistManifest, config: &Config) -> Result<Box<div<St
                         None => targets,
                     },
                 };
+                let install_code_block = build_install_block(config, release, artifact);
                 list.extend(html!(
                     <li class="list-none">
                         <h5 class="capitalize">{text!(title)}</h5>
-                        {unsafe_text!(install_code)}
+                        {install_code_block}
                     </li>
                 ))
             }

--- a/src/site/artifacts/cargo_dist.rs
+++ b/src/site/artifacts/cargo_dist.rs
@@ -6,7 +6,7 @@ use axohtml::elements::{div, span};
 use axohtml::{html, text, unsafe_text};
 use cargo_dist_schema::{Artifact, ArtifactKind, DistManifest, Release};
 
-use super::get_copy_logo;
+use crate::site::artifacts::get_copy_logo;
 
 pub fn get_os(name: &str) -> Option<&str> {
     match name.trim() {

--- a/src/site/artifacts/mod.rs
+++ b/src/site/artifacts/mod.rs
@@ -8,7 +8,7 @@ use axohtml::dom::UnsafeTextNode;
 use axohtml::elements::div;
 use axohtml::unsafe_text;
 
-pub fn get_copy_logo() -> Box<UnsafeTextNode<String>> {
+pub fn get_copyicon() -> Box<UnsafeTextNode<String>> {
     // axohtml does not support SVG for now
     let copy_icon   = unsafe_text!("<svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>");
 

--- a/src/site/artifacts/mod.rs
+++ b/src/site/artifacts/mod.rs
@@ -4,7 +4,16 @@ pub mod page;
 
 use crate::config::Config;
 use crate::errors::*;
+use axohtml::dom::UnsafeTextNode;
 use axohtml::elements::div;
+use axohtml::unsafe_text;
+
+pub fn get_copy_logo() -> Box<UnsafeTextNode<String>> {
+    // axohtml does not support SVG for now
+    let copy_icon   = unsafe_text!("<svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>");
+
+    copy_icon
+}
 
 pub fn build_header(config: &Config) -> Result<Option<Box<div<String>>>> {
     if let Some(artifact) = &config.artifacts {

--- a/src/site/artifacts/package_managers.rs
+++ b/src/site/artifacts/package_managers.rs
@@ -6,7 +6,7 @@ use linked_hash_map::LinkedHashMap;
 use axohtml::elements::div;
 use axohtml::{html, text, unsafe_text};
 
-use super::get_copy_logo;
+use crate::site::artifacts::get_copy_logo;
 
 fn create_package_install_code(code: &str, syntax_theme: &SyntaxTheme) -> String {
     let highlighted_code = syntax_highlight(Some("sh"), code, syntax_theme);

--- a/src/site/artifacts/package_managers.rs
+++ b/src/site/artifacts/package_managers.rs
@@ -6,6 +6,8 @@ use linked_hash_map::LinkedHashMap;
 use axohtml::elements::div;
 use axohtml::{html, text, unsafe_text};
 
+use super::get_copy_logo;
+
 fn create_package_install_code(code: &str, syntax_theme: &SyntaxTheme) -> String {
     let highlighted_code = syntax_highlight(Some("sh"), code, syntax_theme);
     match highlighted_code {
@@ -13,14 +15,25 @@ fn create_package_install_code(code: &str, syntax_theme: &SyntaxTheme) -> String
         Err(_) => format!("<code class='text-center break-all'>{}</code>", code),
     }
 }
-
 // False positive duplicate allocation warning
 // https://github.com/rust-lang/rust-clippy/issues?q=is%3Aissue+redundant_allocation+sort%3Aupdated-desc
 #[allow(clippy::vec_box)]
 pub fn build_list(managers: &LinkedHashMap<String, String>, config: &Config) -> Box<div<String>> {
     let mut list = vec![];
     for (manager, install_code) in managers.iter() {
-        list.extend(html!(<li class="list-none"><h5>{text!(manager)}</h5> {unsafe_text!(create_package_install_code(install_code, &config.syntax_theme))}</li>))
+        let copy_icon = get_copy_logo();
+        list.extend(html!(<li class="list-none"><h5>{text!(manager)}</h5> 
+        <div class="install-code-wrapper">
+        {unsafe_text!(create_package_install_code(install_code, &config.syntax_theme))}
+        <button
+            data-copy={install_code}
+            class="business-button primary button">
+            {copy_icon}
+        </button>
+    </div>
+        
+        
+        </li>))
     }
 
     html!(

--- a/src/site/artifacts/package_managers.rs
+++ b/src/site/artifacts/package_managers.rs
@@ -6,7 +6,7 @@ use linked_hash_map::LinkedHashMap;
 use axohtml::elements::div;
 use axohtml::{html, text, unsafe_text};
 
-use crate::site::artifacts::get_copy_logo;
+use crate::site::artifacts::get_copyicon;
 
 fn create_package_install_code(code: &str, syntax_theme: &SyntaxTheme) -> String {
     let highlighted_code = syntax_highlight(Some("sh"), code, syntax_theme);
@@ -21,7 +21,7 @@ fn create_package_install_code(code: &str, syntax_theme: &SyntaxTheme) -> String
 pub fn build_list(managers: &LinkedHashMap<String, String>, config: &Config) -> Box<div<String>> {
     let mut list = vec![];
     for (manager, install_code) in managers.iter() {
-        let copy_icon = get_copy_logo();
+        let copy_icon = get_copyicon();
         list.extend(html!(<li class="list-none"><h5>{text!(manager)}</h5> 
         <div class="install-code-wrapper">
         {unsafe_text!(create_package_install_code(install_code, &config.syntax_theme))}

--- a/src/site/layout/css.rs
+++ b/src/site/layout/css.rs
@@ -20,14 +20,14 @@ fn concat_minify(css_files: &[String]) -> Result<String> {
 }
 
 pub fn build_fringe() -> Box<link<String>> {
-    const FRINGE_VERSION: &str = "0.0.9";
+    const FRINGE_VERSION: &str = "0.0.10";
     let css_file_name = format!("fringe@{}.css", FRINGE_VERSION);
 
     html!(<link rel="stylesheet" href=css_file_name></link>)
 }
 
 pub fn write_fringe(dist_dir: &str) -> Result<()> {
-    const FRINGE_VERSION: &str = "0.0.9";
+    const FRINGE_VERSION: &str = "0.0.10";
     let css_file_name = format!("fringe@{}.css", FRINGE_VERSION);
     let fringe_href = format!(
         "https://www.unpkg.com/@axodotdev/fringe@{}/themes/",

--- a/src/site/layout/javascript/artifacts.rs
+++ b/src/site/layout/javascript/artifacts.rs
@@ -139,6 +139,7 @@ window.os = os;
 let hit = Array.from(document.querySelectorAll(".target[data-targets]")).find(
   (a) => a.attributes["data-targets"].value.includes(os)
 );
+let backupButton = document.querySelector(".backup-download");
 if (hit) {
   hit.classList.remove("hidden");
 } else {
@@ -146,12 +147,12 @@ if (hit) {
     Array.from(document.querySelectorAll(".target[data-targets]"))
       .find((a) => a.attributes["data-targets"].value.includes(options.mac))
       .classList.remove("hidden");
-  } else {
-    document.querySelector(".backup-download").classList.remove("hidden");
+  } else if (backupButton){
+    backupButton.classList.remove("hidden");
   }
 }
 
-let copyButtons = Array.from(document.getElementsByClassName("copy-clipboard-button"));
+let copyButtons = Array.from(document.querySelectorAll("[data-copy]"));
 if(copyButtons.length) {
   copyButtons.forEach(function(element) {
     element.addEventListener('click', () => {

--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -55,9 +55,8 @@ pub fn build(config: &Config, content: String) -> Result<String> {
             {homepage}
             {favicon}
             {meta_tags}
-            // {fringe_css}
+            {fringe_css}
             {additional_css}
-            <link href="http://localhost:42673/axo-oranda.css" rel="stylesheet" />
         </head>
         <body>
         <div class="container">

--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -8,7 +8,7 @@ use crate::config::{analytics, theme, Config};
 use crate::errors::*;
 use axohtml::{html, text, unsafe_text};
 
-pub fn build(config: &Config, content: String, is_index: bool) -> Result<String> {
+pub fn build(config: &Config, content: String) -> Result<String> {
     let theme = theme::css_class(&config.theme);
     let analytics = analytics::get_analytics(config);
     let google_script = match &config.analytics {
@@ -21,13 +21,7 @@ pub fn build(config: &Config, content: String, is_index: bool) -> Result<String>
     };
     let os_script = match config.artifacts {
         None => None,
-        Some(_) => {
-            if is_index {
-                Some(javascript::build_os_script(&config.path_prefix)?)
-            } else {
-                None
-            }
-        }
+        Some(_) => Some(javascript::build_os_script(&config.path_prefix)?),
     };
     let homepage = config.homepage.as_ref().map(|homepage| {
         html!(
@@ -61,8 +55,9 @@ pub fn build(config: &Config, content: String, is_index: bool) -> Result<String>
             {homepage}
             {favicon}
             {meta_tags}
-            {fringe_css}
+            // {fringe_css}
             {additional_css}
+            <link href="http://localhost:42673/axo-oranda.css" rel="stylesheet" />
         </head>
         <body>
         <div class="container">

--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -8,7 +8,7 @@ use crate::config::{analytics, theme, Config};
 use crate::errors::*;
 use axohtml::{html, text, unsafe_text};
 
-pub fn build(config: &Config, content: String) -> Result<String> {
+pub fn build(config: &Config, content: String, needs_js: bool) -> Result<String> {
     let theme = theme::css_class(&config.theme);
     let analytics = analytics::get_analytics(config);
     let google_script = match &config.analytics {
@@ -21,7 +21,13 @@ pub fn build(config: &Config, content: String) -> Result<String> {
     };
     let os_script = match config.artifacts {
         None => None,
-        Some(_) => Some(javascript::build_os_script(&config.path_prefix)?),
+        Some(_) => {
+            if needs_js {
+                Some(javascript::build_os_script(&config.path_prefix)?)
+            } else {
+                None
+            }
+        }
     };
     let homepage = config.homepage.as_ref().map(|homepage| {
         html!(

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -48,10 +48,9 @@ impl Site {
         let dist = &config.dist_dir;
         Self::create_dist_dir(dist)?;
         for page in self.pages {
-            let js = page.needs_js;
             let asset = axoasset::local::LocalAsset::new(
                 &page.filename.clone(),
-                page.build(config, js)?.into(),
+                page.build(config)?.into(),
             );
             axoasset::local::LocalAsset::write(&asset, dist)?;
         }

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -18,17 +18,17 @@ pub struct Site {
 
 impl Site {
     pub fn build(config: &Config) -> Result<Site> {
-        let index = Page::new_from_file(config, &config.readme_path)?;
+        let index = Page::new_from_file(config, &config.readme_path, true)?;
         let mut pages = vec![index];
         if let Some(files) = &config.additional_pages {
             for file in files {
-                let additional_page = Page::new_from_file(config, file)?;
+                let additional_page = Page::new_from_file(config, file, false)?;
                 pages.push(additional_page)
             }
         }
         if config.artifacts.is_some() {
             let artifacts_html = artifacts::page::build(config)?;
-            let artifacts_page = Page::new_from_contents(artifacts_html, "artifacts.html");
+            let artifacts_page = Page::new_from_contents(artifacts_html, "artifacts.html", true);
             pages.push(artifacts_page)
         }
 
@@ -48,9 +48,10 @@ impl Site {
         let dist = &config.dist_dir;
         Self::create_dist_dir(dist)?;
         for page in self.pages {
+            let js = page.needs_js;
             let asset = axoasset::local::LocalAsset::new(
                 &page.filename.clone(),
-                page.build(config)?.into(),
+                page.build(config, js)?.into(),
             );
             axoasset::local::LocalAsset::write(&asset, dist)?;
         }

--- a/src/site/page.rs
+++ b/src/site/page.rs
@@ -14,23 +14,26 @@ pub struct Page {
     pub contents: String,
     pub filename: String,
     pub is_index: bool,
+    pub needs_js: bool,
 }
 
 impl Page {
-    pub fn new_from_file(config: &Config, source: &str) -> Result<Self> {
+    pub fn new_from_file(config: &Config, source: &str, needs_js: bool) -> Result<Self> {
         let is_index = source == config.readme_path;
         Ok(Page {
             contents: Self::load_and_render_contents(source, &config.syntax_theme)?,
             filename: Self::filename(source, is_index),
             is_index,
+            needs_js,
         })
     }
 
-    pub fn new_from_contents(contents: String, filename: &str) -> Self {
+    pub fn new_from_contents(contents: String, filename: &str, needs_js: bool) -> Self {
         Page {
             contents,
             filename: filename.to_string(),
             is_index: false,
+            needs_js,
         }
     }
 
@@ -39,7 +42,7 @@ impl Page {
         markdown::to_html(contents, syntax_theme)
     }
 
-    pub fn build(self, config: &Config) -> Result<String> {
+    pub fn build(self, config: &Config, needs_js: bool) -> Result<String> {
         let page_contents = if self.is_index {
             let artifacts_header = artifacts::build_header(config)?;
             html!(<div>{artifacts_header}{unsafe_text!(self.contents)}</div>).to_string()
@@ -47,7 +50,7 @@ impl Page {
             let html: Box<div<String>> = html!(<div>{unsafe_text!(self.contents)}</div>);
             html.to_string()
         };
-        layout::build(config, page_contents)
+        layout::build(config, page_contents, needs_js)
     }
 
     pub fn filename(source: &str, is_index: bool) -> String {

--- a/src/site/page.rs
+++ b/src/site/page.rs
@@ -47,7 +47,7 @@ impl Page {
             let html: Box<div<String>> = html!(<div>{unsafe_text!(self.contents)}</div>);
             html.to_string()
         };
-        layout::build(config, page_contents, self.is_index)
+        layout::build(config, page_contents)
     }
 
     pub fn filename(source: &str, is_index: bool) -> String {

--- a/src/site/page.rs
+++ b/src/site/page.rs
@@ -42,7 +42,7 @@ impl Page {
         markdown::to_html(contents, syntax_theme)
     }
 
-    pub fn build(self, config: &Config, needs_js: bool) -> Result<String> {
+    pub fn build(self, config: &Config) -> Result<String> {
         let page_contents = if self.is_index {
             let artifacts_header = artifacts::build_header(config)?;
             html!(<div>{artifacts_header}{unsafe_text!(self.contents)}</div>).to_string()
@@ -50,7 +50,7 @@ impl Page {
             let html: Box<div<String>> = html!(<div>{unsafe_text!(self.contents)}</div>);
             html.to_string()
         };
-        layout::build(config, page_contents, needs_js)
+        layout::build(config, page_contents, self.needs_js)
     }
 
     pub fn filename(source: &str, is_index: bool) -> String {

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -20,14 +20,15 @@ pub fn index(config: &Config) -> String {
         contents: markdown::to_html(readme(), &config.syntax_theme).unwrap(),
         filename: "index.html".to_string(),
         is_index: true,
+        needs_js: true,
     };
-    let contents = page.build(config).unwrap();
-    layout::build(config, contents).unwrap()
+    let contents = page.build(config, true).unwrap();
+    layout::build(config, contents, true).unwrap()
 }
 
 pub fn artifacts(config: &Config) -> String {
     let artifacts_content = artifacts::page::build(config).unwrap();
-    let page = Page::new_from_contents(artifacts_content, "artifacts.html");
-    let contents = page.build(config).unwrap();
-    layout::build(config, contents).unwrap()
+    let page = Page::new_from_contents(artifacts_content, "artifacts.html", true);
+    let contents = page.build(config, true).unwrap();
+    layout::build(config, contents, true).unwrap()
 }

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -22,13 +22,15 @@ pub fn index(config: &Config) -> String {
         is_index: true,
         needs_js: true,
     };
-    let contents = page.build(config, true).unwrap();
-    layout::build(config, contents, true).unwrap()
+    let needs_js = page.needs_js;
+    let contents = page.build(config).unwrap();
+    layout::build(config, contents, needs_js).unwrap()
 }
 
 pub fn artifacts(config: &Config) -> String {
     let artifacts_content = artifacts::page::build(config).unwrap();
     let page = Page::new_from_contents(artifacts_content, "artifacts.html", true);
-    let contents = page.build(config, true).unwrap();
-    layout::build(config, contents, true).unwrap()
+    let needs_js = page.needs_js;
+    let contents = page.build(config).unwrap();
+    layout::build(config, contents, needs_js).unwrap()
 }

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -22,12 +22,12 @@ pub fn index(config: &Config) -> String {
         is_index: true,
     };
     let contents = page.build(config).unwrap();
-    layout::build(config, contents, true).unwrap()
+    layout::build(config, contents).unwrap()
 }
 
 pub fn artifacts(config: &Config) -> String {
     let artifacts_content = artifacts::page::build(config).unwrap();
     let page = Page::new_from_contents(artifacts_content, "artifacts.html");
     let contents = page.build(config).unwrap();
-    layout::build(config, contents, false).unwrap()
+    layout::build(config, contents).unwrap()
 }

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -85,6 +85,7 @@ fn creates_downloads_page() {
     let artifacts_page = page::artifacts(config);
     assert!(artifacts_page.contains("<h3>Downloads</h3>"));
     assert!(artifacts_page.contains("<span>oranda-v0.0.1-prerelease1-x86_64-pc-windows-msvc.zip</span><span>Executable Zip</span><span>x86_64-pc-windows-msvc</span><span><a href=\"https://github.com/axodotdev/oranda/releases/download/v0.0.1-prerelease1/oranda-v0.0.1-prerelease1-x86_64-pc-windows-msvc.zip\">Download</a></span>"));
+    assert!(artifacts_page.contains("<h3>Install via script</h3>"))
 }
 
 #[test]
@@ -94,6 +95,28 @@ fn creates_nav_item_package_managers() {
     let page_html = page::index(config);
     assert!(page_html
         .contains("<a class=\"download-all\" href=\"/artifacts.html\">View all downloads</a>"));
+}
+
+#[test]
+fn creates_copy_to_clipboard_home() {
+    let _guard = TEST_RUNTIME.enter();
+    let config = &oranda_config::cargo_dist();
+    let page_html = page::index(config);
+    assert!(page_html
+        .contains("<button class=\"business-button button copy-clipboard-button primary\" data-copy=\"curl --proto &#39;=https&#39; --tlsv1.2 -L -sSf https://github.com/axodotdev/oranda/releases/download/v0.0.1-prerelease1/installer.sh | sh\">"));
+    assert!(page_html.contains(
+        "<a class=\"business-button button primary\" href=\"installer.sh.txt\">Source</a>"
+    ));
+}
+
+#[test]
+fn creates_copy_to_clipboard_artifacts() {
+    let _guard = TEST_RUNTIME.enter();
+    let config = &oranda_config::package_managers();
+    let page_html = page::artifacts(config);
+    assert!(page_html.contains(
+        "<button class=\"business-button button primary\" data-copy=\"npm install oranda\">"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
- Adds the copy and source buttons to the cargo dist installers
- Adds copy to clipboard to package managers
- Adds tests for all the copy and source stuff

fringe PR: https://github.com/axodotdev/turbo-axo/pull/239
![localhost_3000_artifacts (2)](https://user-images.githubusercontent.com/1051509/217793382-b43f1626-2eee-459a-a332-65c77ee8b189.png)
