### PR TITLE
update to cargo-dist-schema-v0.0.3-prerelease09

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.0.2"
+version = "0.0.3-prerelease09"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abefb2f6a96d862286725aa15c5b6167f07430aef9ca35858061672beac2ac1"
+checksum = "ff37e35c9e08b35b785e98e5fcf24351acf62d4310029dbc9a6889637d491fc8"
 dependencies = [
  "camino",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ammonia = "3"
 axoasset = "0.0.1"
 axohtml = "0.4.1"
 axum = "0.6.2"
-cargo-dist-schema = "0.0.2"
+cargo-dist-schema = "=0.0.3-prerelease09"
 clap = { version = "4", features = ["derive", "help", "usage", "error-context", "wrap_help"] }
 comrak = "0.14"
 console = "0.15.5"

--- a/tests/build/fixtures/oranda_config.rs
+++ b/tests/build/fixtures/oranda_config.rs
@@ -32,7 +32,7 @@ pub fn path_prefix() -> Config {
             "https://raw.githubusercontent.com/axodotdev/axii/main/css/main.css",
         )],
         repository: Some(String::from("https://github.com/axodotdev/oranda")),
-        version: Some(String::from("0.0.1-prerelease1")),
+        version: Some(String::from("0.0.1-prerelease2")),
         ..Default::default()
     }
 }
@@ -47,7 +47,7 @@ pub fn cargo_dist() -> Config {
             "https://raw.githubusercontent.com/axodotdev/oranda/main/README.md",
         )]),
         repository: Some(String::from("https://github.com/axodotdev/oranda")),
-        version: Some(String::from("0.0.1-prerelease1")),
+        version: Some(String::from("0.0.1-prerelease2")),
         ..Default::default()
     }
 }
@@ -62,7 +62,7 @@ pub fn package_managers() -> Config {
             package_managers: Some(package_managers),
         }),
         repository: Some(String::from("https://github.com/axodotdev/oranda")),
-        version: Some(String::from("0.0.1-prerelease1")),
+        version: Some(String::from("0.0.1-prerelease2")),
         ..Default::default()
     }
 }

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -84,7 +84,7 @@ fn creates_downloads_page() {
     let config = &oranda_config::cargo_dist();
     let artifacts_page = page::artifacts(config);
     assert!(artifacts_page.contains("<h3>Downloads</h3>"));
-    assert!(artifacts_page.contains("<span>oranda-v0.0.1-prerelease1-x86_64-pc-windows-msvc.zip</span><span>Executable Zip</span><span>x86_64-pc-windows-msvc</span><span><a href=\"https://github.com/axodotdev/oranda/releases/download/v0.0.1-prerelease1/oranda-v0.0.1-prerelease1-x86_64-pc-windows-msvc.zip\">Download</a></span>"));
+    assert!(artifacts_page.contains("<span>oranda-v0.0.1-prerelease2-x86_64-pc-windows-msvc.zip</span><span>Executable Zip</span><span>x86_64-pc-windows-msvc</span><span><a href=\"https://github.com/axodotdev/oranda/releases/download/v0.0.1-prerelease2/oranda-v0.0.1-prerelease2-x86_64-pc-windows-msvc.zip\">Download</a></span>"));
     assert!(artifacts_page.contains("<h3>Install via script</h3>"))
 }
 
@@ -103,9 +103,9 @@ fn creates_copy_to_clipboard_home() {
     let config = &oranda_config::cargo_dist();
     let page_html = page::index(config);
     assert!(page_html
-        .contains("<button class=\"business-button button copy-clipboard-button primary\" data-copy=\"curl --proto &#39;=https&#39; --tlsv1.2 -L -sSf https://github.com/axodotdev/oranda/releases/download/v0.0.1-prerelease1/installer.sh | sh\">"));
+        .contains("<button class=\"business-button button copy-clipboard-button primary\" data-copy=\"# WARNING: this installer is experimental\ncurl --proto &#39;=https&#39; --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.0.1-prerelease2/oranda-v0.0.1-prerelease2-installer.sh | sh\">"));
     assert!(page_html.contains(
-        "<a class=\"business-button button primary\" href=\"installer.sh.txt\">Source</a>"
+        "<a class=\"business-button button primary\" href=\"oranda-v0.0.1-prerelease2-installer.sh.txt\">Source</a>"
     ));
 }
 


### PR DESCRIPTION
This currently dies because I think the tests read:

https://github.com/axodotdev/oranda/releases/tag/v0.0.1-prerelease1

which is using the 0.0.2 format. Once you have a newer release with that format it should work.