### PR TITLE
fix(err): add fetch and parse errors for cargo dist manifest

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,15 @@ pub enum OrandaError {
     #[error("Could not find a build in {dist_dir}. Did you remember to run `oranda build`?")]
     BuildNotFound { dist_dir: String },
 
+    #[error("Encountered an error (status: {status_code}) while fetching your cargo-dist release manifest at {url}. This often occurs when you haven't yet published a GitHub release for the version set in your Cargo.toml. Consider publishing a release or promoting a draft release for the current version, or updating your Cargo.toml to use an already released version.")]
+    CargoDistManifestFetchError {
+        url: String,
+        status_code: reqwest::StatusCode,
+    },
+
+    #[error("Encountered an error parsing your cargo-dist manifest at {url}. Details: {details}")]
+    CargoDistManifestParseError { url: String, details: String },
+
     #[error("{0}")]
     Other(String),
 }


### PR DESCRIPTION
fixes #189 
<img width="941" alt="Screen Shot 2023-02-25 at 5 22 54 PM" src="https://user-images.githubusercontent.com/1163554/221384079-edeabf6c-1ba6-440c-b563-cfac2b03158c.png">

