### PR TITLE
Ensure we delete the dist directory before building

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,6 +25,11 @@ pub enum OrandaError {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
 
+    #[error(
+        "Failed to create a directory, `{dist_path}` to build your project in. Details:\n{details}"
+    )]
+    DistDirCreationError { dist_path: String, details: String },
+
     #[error("Found an invalid value assigned to ORANDA_CSS environment variable. Please make sure you give a valid path pointing to a css file.")]
     InvalidOrandaCSSOverride { path: String },
 

--- a/src/site/artifacts/cargo_dist.rs
+++ b/src/site/artifacts/cargo_dist.rs
@@ -6,8 +6,8 @@ use cargo_dist_schema as cargo_dist;
 use crate::config::Config;
 use crate::errors::*;
 use crate::site::changelog::{self, GithubRelease};
+use crate::site::link;
 use crate::site::markdown;
-use crate::site::{link, Site};
 
 use crate::site::artifacts;
 
@@ -64,7 +64,6 @@ fn get_installer_path(config: &Config, name: &str, version: &str) -> Result<Stri
     let file_string_future = Asset::load_string(download_link.as_str());
     let file_string = tokio::runtime::Handle::current().block_on(file_string_future)?;
     let file_path = format!("{}.txt", &name);
-    Site::create_dist_dir(&config.dist_dir)?;
     let asset = LocalAsset::new(
         &format!("{}/{}", &config.dist_dir, &file_path),
         file_string.as_bytes().to_vec(),

--- a/tests/build/fixtures/oranda_config.rs
+++ b/tests/build/fixtures/oranda_config.rs
@@ -6,6 +6,14 @@ use oranda::config::Config;
 
 use linked_hash_map::LinkedHashMap;
 
+fn temp_build_dir() -> String {
+    assert_fs::TempDir::new()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
 pub fn no_artifacts() -> Config {
     let mut additional_pages = HashMap::new();
     additional_pages.insert(
@@ -13,6 +21,7 @@ pub fn no_artifacts() -> Config {
         "https://raw.githubusercontent.com/axodotdev/oranda/main/README.md".to_string(),
     );
     Config {
+        dist_dir: temp_build_dir(),
         description: String::from("you axolotl questions"),
         readme_path: String::from(
             "https://raw.githubusercontent.com/axodotdev/oranda/main/README.md",
@@ -28,6 +37,7 @@ pub fn no_artifacts() -> Config {
 
 pub fn path_prefix() -> Config {
     Config {
+        dist_dir: temp_build_dir(),
         path_prefix: Some(String::from("axo")),
         artifacts: Some(Artifacts {
             cargo_dist: Some(true),
@@ -44,6 +54,7 @@ pub fn path_prefix() -> Config {
 
 pub fn cargo_dist() -> Config {
     Config {
+        dist_dir: temp_build_dir(),
         artifacts: Some(Artifacts {
             cargo_dist: Some(true),
             package_managers: None,
@@ -59,6 +70,7 @@ pub fn package_managers() -> Config {
     package_managers.insert(String::from("npm"), String::from("npm install oranda"));
     package_managers.insert(String::from("yarn"), String::from("yarn add oranda"));
     Config {
+        dist_dir: temp_build_dir(),
         artifacts: Some(Artifacts {
             cargo_dist: None,
             package_managers: Some(package_managers),
@@ -71,6 +83,7 @@ pub fn package_managers() -> Config {
 
 pub fn changelog() -> Config {
     Config {
+        dist_dir: temp_build_dir(),
         artifacts: Some(Artifacts {
             cargo_dist: Some(true),
             package_managers: None,

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -1,8 +1,5 @@
 use oranda::config::Config;
-use oranda::site::artifacts;
-use oranda::site::layout;
-use oranda::site::markdown;
-use oranda::site::page::Page;
+use oranda::site::{self, artifacts, layout, markdown, page::Page};
 
 fn readme() -> String {
     r#"
@@ -15,7 +12,12 @@ $ axo | lotl
         .to_string()
 }
 
+fn reset(dist_dir: &str) {
+    site::Site::clean_dist_dir(dist_dir).unwrap();
+}
+
 pub fn index(config: &Config) -> String {
+    reset(&config.dist_dir);
     let page = Page {
         contents: markdown::to_html(readme(), &config.syntax_theme).unwrap(),
         filename: "index.html".to_string(),
@@ -28,6 +30,7 @@ pub fn index(config: &Config) -> String {
 }
 
 pub fn artifacts(config: &Config) -> String {
+    reset(&config.dist_dir);
     let artifacts_content = artifacts::page::build(config).unwrap();
     let page = Page::new_from_contents(artifacts_content, "artifacts.html", true);
     let needs_js = page.needs_js;


### PR DESCRIPTION
- Removes scattered calls to function that ensured there was a dist dir
- Adds one function on the build command to create the dir or if it exists to delete it and create it

closes https://github.com/axodotdev/oranda/issues/210