### PR TITLE
Default to text when no syntax is found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,8 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axoasset"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d142a02f4d5064a72f402a7a750c2f9b23c7355e0c9804d67c0ef22f0421cc8"
+version = "0.2.0"
+source = "git+https://github.com/axodotdev/axoasset?branch=0.2.0#5d30af4af38139d6a407db5adb360007d664c0b9"
 dependencies = [
  "camino",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "oranda"
 
 [dependencies]
 ammonia = "3"
-axoasset = { version = "0.1.1", features = ["json-serde"] }
+axoasset = { branch = "0.2.0", features = ["json-serde"], git = "https://github.com/axodotdev/axoasset" }
 axohtml = "0.5.0"
 axoproject = { version = "0.1.0", default-features = false, features = ["cargo-projects", "npm-projects"] }
 axum = "0.6.2"

--- a/src/site/changelog/github_release.rs
+++ b/src/site/changelog/github_release.rs
@@ -57,7 +57,7 @@ impl GithubRelease {
                 Some(md) => {
                     let cut_body = md.split(cutoff).collect::<Vec<&str>>()[0];
 
-                    markdown::to_html(cut_body.to_string(), syntax_theme)?
+                    markdown::to_html(cut_body, syntax_theme)?
                 }
                 None => String::new(),
             };

--- a/src/site/markdown/mod.rs
+++ b/src/site/markdown/mod.rs
@@ -47,14 +47,14 @@ fn initialize_comrak_options() -> ComrakOptions {
     options
 }
 
-pub fn to_html(markdown: String, syntax_theme: &SyntaxTheme) -> Result<String> {
+pub fn to_html(markdown: &str, syntax_theme: &SyntaxTheme) -> Result<String> {
     let options = initialize_comrak_options();
 
     let mut plugins = ComrakPlugins::default();
     let adapter = Adapters { syntax_theme };
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
-    let unsafe_html = comrak::markdown_to_html_with_plugins(&markdown, &options, &plugins);
+    let unsafe_html = comrak::markdown_to_html_with_plugins(markdown, &options, &plugins);
     let safe_html = Builder::new()
         .add_generic_attributes(&["style", "class", "id"])
         .clean(&unsafe_html)

--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -24,9 +24,15 @@ fn find_syntax<'a>(ps: &'a SyntaxSet, language: &'a str) -> Result<&'a SyntaxRef
         return Ok(syntax_name);
     }
 
-    Err(OrandaError::Other(
-        "Please add the language to your code snippets".to_owned(),
-    ))
+    // this syntax will always be found as it's part of the default set
+    // https://github.com/sublimehq/Packages
+    let plain_text = ps
+        .syntaxes()
+        .iter()
+        .find(|syntax| syntax.name == "Plain Text")
+        .unwrap();
+
+    Ok(plain_text)
 }
 
 const THEMES: &[(&str, &str)] = &[("MaterialTheme", include_str!("MaterialTheme.tmTheme"))];

--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -3,6 +3,7 @@ pub mod syntax_themes;
 use std::collections::BTreeMap;
 
 use crate::errors::*;
+use crate::message::{Message, MessageType};
 use crate::site::markdown::syntax_highlight::syntax_themes::SyntaxTheme;
 use syntect::highlighting::{Theme, ThemeSet};
 use syntect::html::highlighted_html_for_string;
@@ -17,22 +18,31 @@ fn find_syntax<'a>(ps: &'a SyntaxSet, language: &'a str) -> Result<&'a SyntaxRef
     let syntax_name = ps.find_syntax_by_token(language);
 
     if let Some(syntax_extension) = syntax_extension {
-        return Ok(syntax_extension);
+        Ok(syntax_extension)
+    } else if let Some(syntax_name) = syntax_name {
+        Ok(syntax_name)
+    } else {
+        // if we end up here it means that we could not find the provided language
+        // by name or extension. either this means that no language was provided
+        // or the language is not supported. we check if the language str is empty
+        // to see if there was an annotation at all, and if so, warn that it's
+        // unsupported and being overridden as plain text.
+        if !language.is_empty() {
+            let msg = format!("Found syntax highlight language annotation `{language}` which is not currently supported. The annotated block will be shown as plaintext. Please file an issue https://github.com/axodotdev/oranda/issues/new to let us know you'd like to see it supported.");
+            Message::new(MessageType::Warning, &msg).print();
+            tracing::warn!("{}", &msg);
+        }
+
+        // this syntax will always be found as it's part of the default set
+        // https://github.com/sublimehq/Packages
+        let plain_text = ps
+            .syntaxes()
+            .iter()
+            .find(|syntax| syntax.name == "Plain Text")
+            .unwrap();
+
+        Ok(plain_text)
     }
-
-    if let Some(syntax_name) = syntax_name {
-        return Ok(syntax_name);
-    }
-
-    // this syntax will always be found as it's part of the default set
-    // https://github.com/sublimehq/Packages
-    let plain_text = ps
-        .syntaxes()
-        .iter()
-        .find(|syntax| syntax.name == "Plain Text")
-        .unwrap();
-
-    Ok(plain_text)
 }
 
 const THEMES: &[(&str, &str)] = &[("MaterialTheme", include_str!("MaterialTheme.tmTheme"))];

--- a/src/site/page/mod.rs
+++ b/src/site/page/mod.rs
@@ -6,7 +6,7 @@ use crate::site::artifacts;
 use crate::site::layout;
 use crate::site::markdown::{self, SyntaxTheme};
 
-use axoasset::LocalAsset;
+use axoasset::SourceFile;
 use axohtml::{html, unsafe_text};
 
 pub mod source;
@@ -40,7 +40,8 @@ impl Page {
     }
 
     fn load_and_render_contents(source: &str, syntax_theme: &SyntaxTheme) -> Result<String> {
-        let contents = LocalAsset::load_string(source)?;
+        let source = SourceFile::load_local(source)?;
+        let contents = source.contents();
         markdown::to_html(contents, syntax_theme)
     }
 

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -1,7 +1,7 @@
 use oranda::config::Config;
 use oranda::site::{self, artifacts, markdown, page::Page};
 
-fn readme() -> String {
+fn readme() -> &'static str {
     r#"
 # axo
 > a fun side project
@@ -14,10 +14,9 @@ $ axo | lotl
 this block has no highlight annotation
 ```
 "#
-    .to_string()
 }
 
-fn readme_invalid_annotation() -> String {
+fn readme_invalid_annotation() -> &'static str {
     r#"
 # axo
 > a fun side project
@@ -31,7 +30,6 @@ fn this_annotation_will_never_be_supported() {
     println!("this block will render but not be highlighted!");
 }
 ```"#
-        .to_string()
 }
 
 fn reset(dist_dir: &str) {

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -8,6 +8,28 @@ fn readme() -> String {
 
 ```sh
 $ axo | lotl
+```
+
+```
+this block has no highlight annotation
+```
+"#
+    .to_string()
+}
+
+fn readme_invalid_annotation() -> String {
+    r#"
+# axo
+> a fun side project
+
+```sh
+$ axo | lotl
+```
+
+```farts
+fn this_annotation_will_never_be_supported() {
+    println!("this block will render but not be highlighted!");
+}
 ```"#
         .to_string()
 }
@@ -20,6 +42,17 @@ pub fn index(config: &Config) -> String {
     reset(&config.dist_dir);
     let page = Page {
         contents: markdown::to_html(readme(), &config.syntax_theme).unwrap(),
+        filename: "index.html".to_string(),
+        is_index: true,
+        needs_js: true,
+    };
+    page.build(config).unwrap()
+}
+
+pub fn index_with_warning(config: &Config) -> String {
+    reset(&config.dist_dir);
+    let page = Page {
+        contents: markdown::to_html(readme_invalid_annotation(), &config.syntax_theme).unwrap(),
         filename: "index.html".to_string(),
         is_index: true,
         needs_js: true,

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -152,3 +152,11 @@ fn adds_changelog_nav() {
     let page_html = page::index(config);
     assert!(page_html.contains("<a href=\"/changelog.html\">Changelog</a>"));
 }
+
+#[test]
+fn it_renders_code_blocks_with_invalid_annotations() {
+    let _guard = TEST_RUNTIME.enter();
+    let config = &oranda_config::no_artifacts();
+    let page_html = page::index_with_warning(config);
+    assert!(page_html.contains("this block will render but not be highlighted!"));
+}


### PR DESCRIPTION
When no syntax is found in the code block passed we used to give an error, this changes that and makes the default to be the `plain text` one is used 

related https://github.com/axodotdev/oranda/issues/236