### PR TITLE
WIP: migrate to miette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,30 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -116,14 +136,14 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "axoasset"
 version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d910f7c1d30f796d88031b1421200c26a4d82a16b81078e538cfd73b520052e4"
+source = "git+https://github.com/axodotdev/axoasset#07f0356e5444f973cd7d4b7977dccca5790e834a"
 dependencies = [
+ "camino",
  "image",
+ "miette",
  "mime",
  "reqwest",
  "thiserror",
- "toml",
  "url",
 ]
 
@@ -224,6 +244,21 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -411,7 +446,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -429,7 +464,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "terminal_size",
+ "terminal_size 0.2.5",
 ]
 
 [[package]]
@@ -1046,6 +1081,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "globset"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1175,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -1395,6 +1439,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,8 +1644,16 @@ version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07749fb52853e739208049fb513287c6f448de9103dfa78b05ae01f2fc5809bb"
 dependencies = [
+ "backtrace",
+ "is-terminal",
  "miette-derive",
  "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size 0.1.17",
+ "textwrap 0.15.2",
  "thiserror",
  "unicode-width",
 ]
@@ -1773,6 +1831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +1932,7 @@ dependencies = [
  "fs_extra",
  "lazy_static",
  "linked-hash-map",
+ "miette",
  "minifier",
  "reqwest",
  "serde",
@@ -1924,6 +1992,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -2363,6 +2437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+
+[[package]]
 name = "rustix"
 version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,6 +2777,34 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "supports-color"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4806e0b03b9906e76b018a5d821ebf198c8e9dc0829ed3328eeeb5094aed60"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
+dependencies = [
+ "is-terminal",
 ]
 
 [[package]]
@@ -2831,6 +2945,16 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "terminal_size"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
@@ -2851,6 +2975,17 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
  "unicode-width",
 ]
 
@@ -3216,6 +3351,16 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
+dependencies = [
+ "hashbrown",
+ "regex",
+]
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "oranda"
 
 [dependencies]
 ammonia = "3"
-axoasset = "0.0.1"
+axoasset = { version = "0.0.1", git = "https://github.com/axodotdev/axoasset" }
 axohtml = "0.4.1"
 axoproject = { version = "0.1.0", default-features = false, features = ["cargo-projects", "npm-projects"] }
 axum = "0.6.2"
@@ -38,6 +38,7 @@ tracing-appender = "0.2"
 tracing-subscriber = "0.3"
 url = "2.3.1"
 camino = "1.1.4"
+miette = { version = "5.6.0", features = ["fancy"] }
 
 [dev-dependencies]
 assert_cmd="2"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,8 +1,9 @@
+use miette::Diagnostic;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, OrandaError>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum OrandaError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -25,19 +26,29 @@ pub enum OrandaError {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
 
-    #[error(
-        "Failed to create a directory, `{dist_path}` to build your project in. Details:\n{details}"
-    )]
-    DistDirCreationError { dist_path: String, details: String },
+    #[error("Failed to create a directory, `{dist_path}` to build your project in.")]
+    DistDirCreationError {
+        dist_path: String,
+        #[source]
+        details: std::io::Error,
+    },
 
-    #[error("Found an invalid value assigned to ORANDA_CSS environment variable. Please make sure you give a valid path pointing to a css file.")]
+    #[error("Found an invalid value assigned to ORANDA_CSS environment variable.")]
+    #[diagnostic(help("Please make sure you give a valid path pointing to a css file."))]
+    // FIXME: we don't actually print this path?
     InvalidOrandaCSSOverride { path: String },
 
-    #[error("Failed fetching releases from Github. Details:\n{details}")]
-    GithubReleasesFetchError { details: String },
+    #[error("Failed fetching releases from Github.")]
+    GithubReleasesFetchError {
+        #[source]
+        details: reqwest::Error,
+    },
 
-    #[error("Failed parsing response when fetching releases from Github. Details:\n{details}")]
-    GithubReleaseParseError { details: String },
+    #[error("Failed parsing response when fetching releases from Github.")]
+    GithubReleaseParseError {
+        #[source]
+        details: reqwest::Error,
+    },
 
     #[error("Could not find any releases from {repo} with a cargo-dist compatible `dist-manifest.json`.")]
     NoCargoDistReleasesFound { repo: String },
@@ -48,20 +59,31 @@ pub enum OrandaError {
     #[error("failed to read {filedesc} at {path}")]
     FileNotFound { filedesc: String, path: String },
 
-    #[error("failed to parse your repo, current config has repo as: {repo}, please make sure this is correct.Details: {details}")]
-    RepoParseError { repo: String, details: String },
+    #[error("failed to parse your repo, current config has repo as: {repo}")]
+    #[diagnostic(help("please make sure this is correct."))]
+    RepoParseError {
+        repo: String,
+        #[diagnostic_source]
+        details: miette::Report,
+    },
 
-    #[error("Could not find a build in {dist_dir}. Did you remember to run `oranda build`?")]
+    #[error("Could not find a build in {dist_dir}.")]
+    #[diagnostic(help("Did you remember to run `oranda build`?"))]
     BuildNotFound { dist_dir: String },
 
-    #[error("Encountered an error (status: {status_code}) while fetching your cargo-dist release manifest at {url}. This often occurs when you haven't yet published a GitHub release for the version set in your Cargo.toml. Consider publishing a release or promoting a draft release for the current version, or updating your Cargo.toml to use an already released version.")]
+    #[error("Encountered an error (status: {status_code}) while fetching your cargo-dist release manifest at {url}.")]
+    #[diagnostic(help("This often occurs when you haven't yet published a GitHub release for the version set in your Cargo.toml. Consider publishing a release or promoting a draft release for the current version, or updating your Cargo.toml to use an already released version."))]
     CargoDistManifestFetchError {
         url: String,
         status_code: reqwest::StatusCode,
     },
 
-    #[error("Encountered an error parsing your cargo-dist manifest at {url}. Details: {details}")]
-    CargoDistManifestParseError { url: String, details: String },
+    #[error("Encountered an error parsing your cargo-dist manifest at {url}.")]
+    CargoDistManifestParseError {
+        url: String,
+        #[source]
+        details: reqwest::Error,
+    },
 
     #[error("{0}")]
     Other(String),

--- a/src/site/artifacts/cargo_dist.rs
+++ b/src/site/artifacts/cargo_dist.rs
@@ -30,10 +30,7 @@ pub fn fetch_manifest(config: &Config) -> Result<cargo_dist::DistManifest> {
         match reqwest::blocking::get(&url)?.error_for_status() {
             Ok(resp) => match resp.json::<cargo_dist::DistManifest>() {
                 Ok(manifest) => Ok(manifest),
-                Err(e) => Err(OrandaError::CargoDistManifestParseError {
-                    url,
-                    details: e.to_string(),
-                }),
+                Err(e) => Err(OrandaError::CargoDistManifestParseError { url, details: e }),
             },
             Err(e) => Err(OrandaError::CargoDistManifestFetchError {
                 url,

--- a/src/site/changelog/mod.rs
+++ b/src/site/changelog/mod.rs
@@ -6,6 +6,7 @@ pub use github_release::GithubRelease;
 use axohtml::elements::{div, li, section};
 use axohtml::html;
 use axohtml::text;
+use miette::{miette, IntoDiagnostic};
 use reqwest::header::USER_AGENT;
 
 use crate::config::Config;
@@ -31,11 +32,11 @@ fn build_prerelease_toggle(releases: Vec<GithubRelease>) -> Option<Box<div<Strin
 }
 
 pub fn fetch_releases(repo: &str) -> Result<Vec<GithubRelease>> {
-    let repo_parsed = match Url::parse(repo) {
+    let repo_parsed = match Url::parse(repo).into_diagnostic() {
         Ok(parsed) => Ok(parsed),
         Err(parse_error) => Err(OrandaError::RepoParseError {
             repo: repo.to_string(),
-            details: parse_error.to_string(),
+            details: parse_error,
         }),
     };
     let binding = repo_parsed?;
@@ -57,8 +58,9 @@ pub fn fetch_releases(repo: &str) -> Result<Vec<GithubRelease>> {
     } else {
         Err(OrandaError::RepoParseError {
             repo: binding.to_string(),
-            details: "This URL is not structured the expected way, expected more segments-"
-                .to_owned(),
+            details: miette!(
+                "This URL is not structured the expected way, expected more segments-"
+            ),
         })
     }
 }
@@ -67,13 +69,9 @@ fn parse_response(response: reqwest::blocking::Response) -> Result<Vec<GithubRel
     match response.error_for_status() {
         Ok(r) => match r.json() {
             Ok(releases) => Ok(releases),
-            Err(e) => Err(OrandaError::GithubReleaseParseError {
-                details: e.to_string(),
-            }),
+            Err(e) => Err(OrandaError::GithubReleaseParseError { details: e }),
         },
-        Err(e) => Err(OrandaError::GithubReleasesFetchError {
-            details: e.to_string(),
-        }),
+        Err(e) => Err(OrandaError::GithubReleasesFetchError { details: e }),
     }
 }
 

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -101,7 +101,7 @@ impl Site {
             Ok(_) => Ok(()),
             Err(e) => Err(OrandaError::DistDirCreationError {
                 dist_path: dist_path.to_string(),
-                details: e.to_string(),
+                details: e,
             }),
         }
     }


### PR DESCRIPTION
currently this produces output like:

![image](https://user-images.githubusercontent.com/1136864/228682677-362e6c1e-bb96-4d7e-b731-a150f0738914.png)

(I imagine you'll want that to be better...)

This PR has three fundamental parts (all done together since they have to be done in lockstep):

* update to the miette version of axoasset (currently via git, so super don't merge)
* update OrandaError to be a proper miette::Diagnostic
* do a crapton of stuff in main to register a bunch of hooks and mess with colors and json output

Unlike libraries, applications "should" register hooks to produce final miette output (otherwise they'll behave like normal thiserror Errors). Also note that to emit a miette Diagnostic you need to:

* wrap it in a miette::Report
* *Debug* format it (`{:?}`)

This is for... Reasons that I can't remember the full details of. If you Display format it (`{}`) you'll get thiserror-style output. I forget what the Report does, if anything. Honestly I might be cargo-culting that at this point.

json error output is currently dead code, but I figured I'd toss it in there tentatively since you'll probably want it for Web Services. A lot of this code is messy gunk that's been copied several times. This version is copied from cargo-dist. If there's anything you Hate there's probably a decent argument for it. I think for instance the current panic hook will swallow the actual backtrace..? I thought I fixed this in cargo-dist but I might be wrong. I guess technically it's prettier but... bleh.