### PR TITLE
Build changelogs in separate pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,19 +178,23 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axoasset"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d142a02f4d5064a72f402a7a750c2f9b23c7355e0c9804d67c0ef22f0421cc8"
+checksum = "cc3347278d8b9a15b998d45a0ff07919ca2b98795445aa550cd4222ddacd00e6"
 dependencies = [
  "camino",
+ "flate2",
  "image",
  "miette",
  "mime",
  "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "thiserror",
  "url",
+ "xz2",
+ "zip",
 ]
 
 [[package]]
@@ -327,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +383,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -403,6 +434,27 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "camino"
@@ -454,6 +506,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -484,6 +539,15 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -594,6 +658,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +678,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -666,6 +745,16 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cxx"
@@ -800,6 +889,17 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "dirs"
@@ -956,6 +1056,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1188,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1220,6 +1342,15 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1464,6 +1595,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1727,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1877,6 +2028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,12 +2183,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 dependencies = [
  "camino",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -2570,6 +2750,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,6 +2914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "supports-color"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2997,17 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3207,6 +3426,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicase"
@@ -3628,6 +3853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "xdg"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,12 +3871,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.20",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "oranda"
 
 [dependencies]
 ammonia = "3"
-axoasset = {version = "0.1.1", features = ["json-serde"] }
+axoasset = {version = "0.2.0", features = ["json-serde"] }
 axohtml = "0.5.0"
 axoproject = { version = "0.1.0", default-features = false, features = ["cargo-projects", "npm-projects"] }
 axum = "0.6.2"

--- a/oranda-css/css/buttons.css
+++ b/oranda-css/css/buttons.css
@@ -3,7 +3,7 @@
 }
 
 .button.primary {
-  @apply text-axo-black bg-axo-orange hover:bg-axo-pink border-transparent;
+  @apply text-axo-black hover:text-axo-black bg-axo-orange hover:bg-axo-pink border-transparent;
 }
 
 .button.secondary {

--- a/oranda-css/css/components.css
+++ b/oranda-css/css/components.css
@@ -25,5 +25,7 @@ footer {
 }
 
 .repo_banner > a {
-  @apply flex justify-center gap-2 items-start text-slate-50 dark:text-axo-black h-[20px];
+  @apply flex justify-center gap-2 items-start 
+  hover:text-slate-50
+  text-slate-50 dark:text-axo-black dark:hover:text-axo-black h-[20px];
 }

--- a/oranda-css/css/components.css
+++ b/oranda-css/css/components.css
@@ -25,7 +25,5 @@ footer {
 }
 
 .repo_banner > a {
-  @apply flex justify-center gap-2 items-start 
-  hover:text-slate-50
-  text-slate-50 dark:text-axo-black dark:hover:text-axo-black h-[20px];
+  @apply flex justify-center gap-2 items-start hover:text-slate-50 text-slate-50 dark:text-axo-black dark:hover:text-axo-black h-[20px];
 }

--- a/oranda-css/css/components.css
+++ b/oranda-css/css/components.css
@@ -25,5 +25,5 @@ footer {
 }
 
 .repo_banner > a {
-  @apply flex justify-center gap-2 items-start hover:text-slate-50 text-slate-50 dark:text-axo-black dark:hover:text-axo-black h-[20px];
+  @apply flex justify-center gap-2 items-start hover:text-slate-50 text-slate-50 dark:text-axo-black dark:hover:text-axo-black h-[20px] hover:underline hover:underline-offset-1 dark:hover:decoration-axo-black hover:decoration-slate-50;
 }

--- a/oranda-css/css/pages/artifacts.css
+++ b/oranda-css/css/pages/artifacts.css
@@ -15,7 +15,11 @@
 }
 
 .detect {
-  @apply text-center text-slate-500;
+  @apply text-center text-slate-500 pr-2 md:pr-0;
+}
+
+.detect + a {
+  @apply block sm:inline my-2 sm:my-0;
 }
 
 .detect .detected-os {
@@ -27,7 +31,7 @@
 }
 
 .artifact-header > h4 {
-  @apply text-center;
+  @apply text-center -mb-2;
 }
 
 .artifact-header {
@@ -35,7 +39,7 @@
 }
 
 .artifact-header > div:not(.install-code-wrapper) {
-  @apply flex gap-4 justify-center items-center mt-4;
+  @apply md:flex md:gap-4 justify-center text-center md:text-left items-center mt-4;
 }
 
 .backup-download {
@@ -56,4 +60,8 @@
 
 .install-code-wrapper > .button.copy-clipboard-button {
   @apply rounded-none border-r-axo-black border-r-2;
+}
+
+.published-date {
+  @apply block mb-2;
 }

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -21,7 +21,7 @@ pub fn build(context: &Context, config: &Config) -> Result<String> {
 
         let link = format!("#{}", &release.source.tag_name);
 
-        releases_html.extend(build_page_preview(release, config)?);
+        releases_html.extend(build_page_preview(release, config, true)?);
         releases_nav.extend(
             html!(<li class=classnames><a href=link>{text!(&release.source.tag_name)}</a></li>),
         )
@@ -44,7 +44,45 @@ pub fn build(context: &Context, config: &Config) -> Result<String> {
     .to_string())
 }
 
-pub fn build_page_preview(release: &Release, config: &Config) -> Result<Box<section<String>>> {
+/// Builds a page for every release. Returns a vec of tuples, the first element being the
+/// release name to be used for the filename, and the second element being the content of
+/// the page itself.
+pub fn build_all(context: &Context, config: &Config) -> Result<Vec<(String, String)>> {
+    let mut releases = vec![];
+    for release in context.releases.iter() {
+        releases.push((
+            release.source.tag_name.clone(),
+            build_single_release(context, config, release)?,
+        ))
+    }
+
+    Ok(releases)
+}
+
+/// Builds a single, standalone release page.
+pub fn build_single_release(
+    _context: &Context,
+    config: &Config,
+    release: &Release,
+) -> Result<String> {
+    let preview = build_page_preview(release, config, false);
+
+    Ok(html!(
+         <div>
+            <h1>{text!(format!("Release {}", &release.source.tag_name))}</h1>
+            <div class="releases-body">
+                {preview}
+            </div>
+        </div>
+    )
+    .to_string())
+}
+
+pub fn build_page_preview(
+    release: &Release,
+    config: &Config,
+    include_header: bool,
+) -> Result<Box<section<String>>> {
     let tag_name = &release.source.tag_name;
     let title = release.source.name.as_ref().unwrap_or(tag_name);
 
@@ -61,22 +99,23 @@ pub fn build_page_preview(release: &Release, config: &Config) -> Result<Box<sect
     };
     let link = format!("#{}", &tag_name);
     let body = build_release_body(release, config)?;
+    let header_class = if include_header { "" } else { "hidden" };
 
     Ok(html!(
-    <section class=classnames>
-        <h2 id=id><a href=link>{text!(title)}</a></h2>
-        <div class="release-info">
-            <span class="flex items-center gap-2">
-                {icons::tag()}{text!(tag_name)}
-            </span>
-            <span class="flex items-center gap-2">
-                {icons::date()}{text!(&formatted_date)}
-            </span>
-        </div>
-        <div class="release-body mb-6">
-            {unsafe_text!(body)}
-        </div>
-    </section>
+        <section class=classnames>
+            <h2 class=header_class id=id><a href=link>{text!(title)}</a></h2>
+            <div class="release-info">
+                <span class="flex items-center gap-2">
+                    {icons::tag()}{text!(tag_name)}
+                </span>
+                <span class="flex items-center gap-2">
+                    {icons::date()}{text!(&formatted_date)}
+                </span>
+            </div>
+            <div class="release-body mb-6">
+                {unsafe_text!(body)}
+            </div>
+        </section>
     ))
 }
 

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -19,7 +19,7 @@ pub fn build(context: &Context, config: &Config) -> Result<String> {
             ""
         };
 
-        let link = format!("#{}", &release.source.tag_name);
+        let link = format!("{}.html", &release.source.tag_name);
 
         releases_html.extend(build_page_preview(release, config, true)?);
         releases_nav.extend(
@@ -66,10 +66,15 @@ pub fn build_single_release(
     release: &Release,
 ) -> Result<String> {
     let preview = build_page_preview(release, config, false);
+    let title = release
+        .source
+        .name
+        .as_ref()
+        .unwrap_or(&release.source.tag_name);
 
     Ok(html!(
          <div>
-            <h1>{text!(format!("Release {}", &release.source.tag_name))}</h1>
+            <h1>{text!(title)}</h1>
             <div class="releases-body">
                 {preview}
             </div>
@@ -81,7 +86,7 @@ pub fn build_single_release(
 pub fn build_page_preview(
     release: &Release,
     config: &Config,
-    include_header: bool,
+    is_page: bool,
 ) -> Result<Box<section<String>>> {
     let tag_name = &release.source.tag_name;
     let title = release.source.name.as_ref().unwrap_or(tag_name);
@@ -97,9 +102,13 @@ pub fn build_page_preview(
     } else {
         "release"
     };
-    let link = format!("#{}", &tag_name);
+    let link = if is_page {
+        format!("{}.html", &tag_name)
+    } else {
+        format!("#{}", &tag_name)
+    };
     let body = build_release_body(release, config)?;
-    let header_class = if include_header { "" } else { "hidden" };
+    let header_class = if is_page { "" } else { "hidden" };
 
     Ok(html!(
         <section class=classnames>

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -19,7 +19,7 @@ pub fn build(context: &Context, config: &Config) -> Result<String> {
             ""
         };
 
-        let link = format!("{}.html", &release.source.tag_name);
+        let link = format!("changelog/{}.html", &release.source.tag_name);
 
         releases_html.extend(build_page_preview(release, config, true)?);
         releases_nav.extend(
@@ -103,7 +103,7 @@ pub fn build_page_preview(
         "release"
     };
     let link = if is_page {
-        format!("{}.html", &tag_name)
+        format!("changelog/{}.html", &tag_name)
     } else {
         format!("#{}", &tag_name)
     };

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -52,7 +52,7 @@ pub fn build_all(context: &Context, config: &Config) -> Result<Vec<(String, Stri
     for release in context.releases.iter() {
         releases.push((
             release.source.tag_name.clone(),
-            build_single_release(context, config, release)?,
+            build_single_release(config, release)?,
         ))
     }
 
@@ -60,11 +60,7 @@ pub fn build_all(context: &Context, config: &Config) -> Result<Vec<(String, Stri
 }
 
 /// Builds a single, standalone release page.
-pub fn build_single_release(
-    _context: &Context,
-    config: &Config,
-    release: &Release,
-) -> Result<String> {
+pub fn build_single_release(config: &Config, release: &Release) -> Result<String> {
     let preview = build_page_preview(release, config, false);
     let title = release
         .source

--- a/src/site/layout/css.rs
+++ b/src/site/layout/css.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::fs;
 
-use crate::config::Config;
 use crate::errors::*;
 use crate::message::{Message, MessageType};
 
@@ -25,8 +24,8 @@ fn concat_minify(css_files: &[String]) -> Result<String> {
     Ok(css)
 }
 
-pub fn build_oranda(config: &Config) -> Result<Box<link<String>>> {
-    let dist_dir = &config.dist_dir;
+pub fn build_oranda(dist_dir: &str, path_prefix: &Option<String>) -> Result<Box<link<String>>> {
+    let dist_dir = dist_dir;
     match env::var("ORANDA_CSS") {
         Ok(path) => {
             let msg = format!("Overriding oranda_css path with {}", &path);
@@ -42,7 +41,7 @@ pub fn build_oranda(config: &Config) -> Result<Box<link<String>>> {
             fs::rename(fetched_oranda, format!("{dist_dir}/{path}"))?;
         }
     };
-    let abs_path = crate::site::link::generate(&config.path_prefix, "oranda.css");
+    let abs_path = crate::site::link::generate(path_prefix, "oranda.css");
     Ok(html!(<link rel="stylesheet" href=abs_path></link>))
 }
 

--- a/src/site/layout/css.rs
+++ b/src/site/layout/css.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 
+use crate::config::Config;
 use crate::errors::*;
 use crate::message::{Message, MessageType};
 
@@ -24,7 +25,8 @@ fn concat_minify(css_files: &[String]) -> Result<String> {
     Ok(css)
 }
 
-pub fn build_oranda(dist_dir: &str) -> Result<Box<link<String>>> {
+pub fn build_oranda(config: &Config) -> Result<Box<link<String>>> {
+    let dist_dir = &config.dist_dir;
     match env::var("ORANDA_CSS") {
         Ok(path) => {
             let msg = format!("Overriding oranda_css path with {}", &path);
@@ -40,7 +42,8 @@ pub fn build_oranda(dist_dir: &str) -> Result<Box<link<String>>> {
             fs::rename(fetched_oranda, format!("{dist_dir}/{path}"))?;
         }
     };
-    Ok(html!(<link rel="stylesheet" href="oranda.css"></link>))
+    let abs_path = crate::site::link::generate(&config.path_prefix, "oranda.css");
+    Ok(html!(<link rel="stylesheet" href=abs_path></link>))
 }
 
 pub fn build_additional() -> Box<link<String>> {

--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -55,7 +55,7 @@ impl Layout {
         } else {
             None
         };
-        let oranda_css = css::build_oranda(config)?;
+        let oranda_css = css::build_oranda(&config.dist_dir, &config.path_prefix)?;
         let analytics = Analytics::new(config)?;
         let template: String = html!(
         <html lang="en" id="oranda" class=theme>

--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -55,7 +55,7 @@ impl Layout {
         } else {
             None
         };
-        let oranda_css = css::build_oranda(&config.dist_dir)?;
+        let oranda_css = css::build_oranda(config)?;
         let analytics = Analytics::new(config)?;
         let template: String = html!(
         <html lang="en" id="oranda" class=theme>

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use axoasset::LocalAsset;
+use camino::Utf8Path;
 
 use crate::config::Config;
 use crate::data::Context;
@@ -64,15 +65,15 @@ impl Site {
                 let changelog_page =
                     Page::new_from_contents(changelog_html, "changelog.html", &layout_template);
                 let changelog_releases = changelog::build_all(&context, config)?;
+                pages.push(changelog_page);
                 for (name, content) in changelog_releases {
                     let page = Page::new_from_contents(
                         content,
-                        &format!("{}.html", name),
+                        &format!("changelog/{}.html", name),
                         &layout_template,
                     );
                     pages.push(page);
                 }
-                pages.push(changelog_page);
             }
         }
 
@@ -90,7 +91,15 @@ impl Site {
     pub fn write(self, config: &Config) -> Result<()> {
         let dist = &config.dist_dir;
         for page in self.pages {
-            LocalAsset::write_new(&page.contents, &page.filename, dist)?;
+            // FIXME: We have to do some gymnastics here due to `LocalAsset::write_new_all` taking filename and dest
+            // path separately. Hopefully in a future version of axoasset, this only takes one parameter instead of
+            // two, and we can just add the page filename to the dest path and pass it in.
+            let full_path = Utf8Path::new(&config.dist_dir).join(&page.filename);
+            LocalAsset::write_new_all(
+                &page.contents,
+                full_path.file_name().unwrap(),
+                full_path.parent().unwrap().as_str(),
+            )?;
         }
         if let Some(book_path) = &config.md_book {
             Self::copy_static(dist, book_path)?;

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -63,6 +63,15 @@ impl Site {
                 let changelog_html = changelog::build(&context, config)?;
                 let changelog_page =
                     Page::new_from_contents(changelog_html, "changelog.html", &layout_template);
+                let changelog_releases = changelog::build_all(&context, config)?;
+                for (name, content) in changelog_releases {
+                    let page = Page::new_from_contents(
+                        content,
+                        &format!("{}.html", name),
+                        &layout_template,
+                    );
+                    pages.push(page);
+                }
                 pages.push(changelog_page);
             }
         }

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -52,7 +52,7 @@ fn it_adds_oranda_css() {
     let page = page::index(&config, &layout);
     assert!(page
         .contents
-        .contains("<link href=\"oranda.css\" rel=\"stylesheet\"/>"));
+        .contains("<link href=\"/oranda.css\" rel=\"stylesheet\"/>"));
 }
 
 #[test]


### PR DESCRIPTION
With this PR, every changelog item now gets rendered at `changelog/{tagname}.html`.

![CleanShot 2023-05-04 at 13 47 06@2x](https://user-images.githubusercontent.com/6445316/236194867-4e381aba-0418-498c-b99d-973666404692.png)

I've left the existing index page largely unchanged, with the exception of making the heading and sidebar links link to the respective changelog page, but we might want to consider shortening the release body for brevity or something.

Current concerns:

- I've had to modify the CSS link to become absolute, it should work with sites with path prefixes, but what about sites without? Need to test this
- Are all tag names URL-safe (I assume not) or do we need to run them through a slug function?
- Do we want a link back to the changelog index page on every individual page?