### PR TITLE
small fixes for non-cargo dist projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,26 +244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axoproject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e3f2b1bd648e1ed72a3051313aff394cf35c6a5bdd50007d39285d44ba7ce"
-dependencies = [
- "camino",
- "console",
- "guppy",
- "miette",
- "node-semver",
- "oro-common",
- "oro-package-spec",
- "semver",
- "serde",
- "serde_json",
- "toml_edit",
- "tracing",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,12 +392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
-
-[[package]]
 name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,9 +435,6 @@ name = "camino"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "cargo-dist-schema"
@@ -479,45 +450,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
-]
-
-[[package]]
-name = "cfg-expr"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a327683d7499ecc47369531a679fe38acdd300e09bf8c852d08b1e10558622bd"
-dependencies = [
- "smallvec",
- "target-lexicon",
 ]
 
 [[package]]
@@ -614,16 +552,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "comrak"
@@ -798,78 +726,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "debug-ignore"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
-
-[[package]]
-name = "derive_builder"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
-dependencies = [
- "derive_builder_core",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1254,38 +1110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "guppy"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f822a2716041492e071691606474f5a7e4fa7c2acbfd7da7b29884fb448291c7"
-dependencies = [
- "camino",
- "cargo_metadata",
- "cfg-if",
- "debug-ignore",
- "fixedbitset",
- "guppy-workspace-hack",
- "indexmap",
- "itertools",
- "nested",
- "once_cell",
- "pathdiff",
- "petgraph",
- "semver",
- "serde",
- "serde_json",
- "smallvec",
- "static_assertions",
- "target-spec",
-]
-
-[[package]]
-name = "guppy-workspace-hack"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
-
-[[package]]
 name = "h2"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,12 +1296,6 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1842,12 +1660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb022374af2f446981254e6bf9efb6e2c9e1a53176d395fca02792fd4435729"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,39 +1718,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nested"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "node-semver"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f390c1756333538f2aed01cf280a56bc683e199b9804a504df6e7320d40116"
-dependencies = [
- "bytecount",
- "miette",
- "nom",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2087,7 +1870,6 @@ dependencies = [
  "axoasset",
  "axocli",
  "axohtml",
- "axoproject",
  "axum",
  "camino",
  "cargo-dist-schema",
@@ -2111,39 +1893,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "oro-common"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7d244015f981688ebed3945be64c61c387c79f088565db581f596789c6b30a"
-dependencies = [
- "derive_builder",
- "miette",
- "node-semver",
- "nom",
- "pathdiff",
- "serde",
- "serde_json",
- "thiserror",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "oro-package-spec"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fdb86466da687058b08cf8d64f5e58fdf85e2adf39a1059e00abe7f6e2b1cf"
-dependencies = [
- "bytecount",
- "miette",
- "node-semver",
- "nom",
- "percent-encoding",
- "thiserror",
  "url",
 ]
 
@@ -2191,15 +1940,6 @@ dependencies = [
  "base64ct",
  "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-dependencies = [
- "camino",
 ]
 
 [[package]]
@@ -2682,9 +2422,6 @@ name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -2857,12 +2594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,23 +2739,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
-
-[[package]]
-name = "target-spec"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb0303f2cecb4171c439135b28c33fe9da7b9fd7816fe674761834da70c9778"
-dependencies = [
- "cfg-expr",
- "guppy-workspace-hack",
- "target-lexicon",
 ]
 
 [[package]]
@@ -3275,24 +2989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
-
-[[package]]
-name = "toml_edit"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1541ba70885967e662f69d31ab3aeca7b1aaecfcd58679590b893e9239c3646"
-dependencies = [
- "combine",
- "indexmap",
- "itertools",
- "toml_datetime",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3500,7 +3196,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ name = "oranda"
 ammonia = "3"
 axoasset = {version = "0.2.0", features = ["json-serde"] }
 axohtml = "0.5.0"
-axoproject = { version = "0.1.0", default-features = false, features = ["cargo-projects", "npm-projects"] }
 axum = "0.6.2"
 cargo-dist-schema = "=0.0.3"
 chrono = "0.4.23"

--- a/src/config/project/javascript.rs
+++ b/src/config/project/javascript.rs
@@ -1,0 +1,90 @@
+use axoasset::Asset;
+use serde::Deserialize;
+
+use crate::config::ProjectConfig;
+use crate::errors::*;
+use std::path::{Path, PathBuf};
+
+static PACKAGE_JSON: &str = "./package.json";
+
+/// A package.json file
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub struct PackageJson {
+    /// Name of the package
+    pub name: String,
+    /// Version of the package
+    pub version: Option<String>,
+    /// Description of the package
+    pub description: String,
+    /// Link to the homepage
+    pub homepage: Option<String>,
+    /// Link to the repository
+    pub repository: Option<Repository>,
+    /// License of the package
+    pub license: Option<String>,
+}
+
+/// A link to a repository
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum Repository {
+    /// Shorthand syntax
+    Short(String),
+    /// Long form
+    Long(LongRepository),
+}
+
+/// A link to a repository
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub struct LongRepository {
+    /// The type of link it is
+    pub r#type: String,
+    /// The url
+    pub url: String,
+    /// The subdirectory to find the project at
+    pub directory: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct JavaScript {}
+impl JavaScript {
+    pub fn read(&self, project_root: &Option<PathBuf>) -> Result<ProjectConfig> {
+        let path = JavaScript::config(project_root);
+        let package_json_future = Asset::load_string(path.to_str().unwrap());
+        let package_json = tokio::runtime::Handle::current().block_on(package_json_future)?;
+        let data: PackageJson = serde_json::from_str(&package_json)?;
+
+        let repository = data.repository.map(|repo| match repo {
+            // TODO: process this into a proper URL?
+            //
+            // It can be things like:
+            //
+            // * "npm/npm"
+            // * "github:user/repo"
+            // * "gist:11081aaa281"
+            // * "bitbucket:user/repo"
+            // * "gitlab:user/repo"
+            //
+            // Using the same syntax as https://docs.npmjs.com/cli/v7/commands/npm-install
+            Repository::Short(repo) => repo,
+            Repository::Long(repo) => repo.url,
+        });
+
+        Ok(ProjectConfig {
+            name: data.name,
+            description: data.description,
+            homepage: data.homepage,
+            repository,
+            version: data.version,
+            license: data.license,
+        })
+    }
+
+    pub fn config(project_root: &Option<PathBuf>) -> PathBuf {
+        if let Some(root) = project_root {
+            Path::new(root).join(PACKAGE_JSON)
+        } else {
+            Path::new(PACKAGE_JSON).to_path_buf()
+        }
+    }
+}

--- a/src/config/project/mod.rs
+++ b/src/config/project/mod.rs
@@ -1,10 +1,15 @@
 use std::path::PathBuf;
 
-use camino::Utf8PathBuf;
 use serde::Deserialize;
+
+mod javascript;
+mod rust;
 
 use crate::errors::*;
 use crate::message::{Message, MessageType};
+
+pub use javascript::JavaScript;
+pub use rust::Rust;
 
 #[derive(Debug, Deserialize, Eq, PartialEq)]
 pub struct ProjectConfig {
@@ -18,74 +23,35 @@ pub struct ProjectConfig {
 
 impl ProjectConfig {
     pub fn load(project_root: Option<PathBuf>) -> Result<Option<ProjectConfig>> {
-        if let Some(project) = ProjectConfig::get_project(&project_root) {
-            match project.kind {
-                axoproject::WorkspaceKind::Rust => {
-                    Message::new(MessageType::Info, "Detected Rust project...").print();
-                    tracing::info!("Detected Rust project...");
-                }
-                axoproject::WorkspaceKind::Javascript => {
-                    Message::new(MessageType::Info, "Detected JavaScript project...").print();
-                    tracing::info!("Detected JavaScript project...");
-                }
-            }
-
-            // FIXME: Oranda currently has no notion of workspaces with multiple binaries,
-            // so we just refuse to make progress if we find more than one.
-
-            let mut bin_package = None;
-            for (_idx, package) in project.packages() {
-                if !package.binaries.is_empty() {
-                    if bin_package.is_none() {
-                        bin_package = Some(package);
-                    } else {
-                        Message::new(
-                            MessageType::Warning,
-                            "Your project has multiple binaries, Oranda doesn't support that",
-                        )
-                        .print();
-                        tracing::warn!(
-                            "Your project has multiple binaries, Oranda doesn't support that"
-                        );
-                        return Ok(None);
-                    }
-                }
-            }
-
-            if let Some(package) = bin_package {
-                return Ok(Some(ProjectConfig {
-                    name: package.name.clone(),
-                    description: package.description.clone().unwrap_or_default(),
-                    homepage: package.homepage_url.clone(),
-                    repository: package.repository_url.clone(),
-                    version: package.version.as_ref().map(|v| v.to_string()),
-                    license: package.license.clone(),
-                }));
-            } else {
-                Message::new(
-                    MessageType::Warning,
-                    "Your project doesn't seem to have binaries",
-                )
-                .print();
-                tracing::warn!("Your project doesn't seem to have binaries");
-                Ok(None)
+        if let Some(ptype) = ProjectConfig::detect(&project_root) {
+            match ptype {
+                Type::JavaScript(project) => Ok(Some(project.read(&project_root)?)),
+                Type::Rust(project) => Ok(Some(project.read(&project_root)?)),
             }
         } else {
             Ok(None)
         }
     }
 
-    pub fn get_project(project_root: &Option<PathBuf>) -> Option<axoproject::WorkspaceInfo> {
-        // Get the general info about the project (via axo-project)
-        let start_dir = project_root.clone().unwrap_or_else(|| {
-            std::env::current_dir().expect("couldn't get current working dir!?")
-        });
-        let start_dir = Utf8PathBuf::from_path_buf(start_dir).expect("project path isn't utf8!?");
-        let Some(project) = axoproject::get_project(&start_dir) else {
+    pub fn detect(project_root: &Option<PathBuf>) -> Option<Type> {
+        if Rust::config(project_root).exists() {
+            Message::new(MessageType::Info, "Detected Rust project...").print();
+            tracing::info!("Detected Rust project...");
+            Some(Type::Rust(Rust {}))
+        } else if JavaScript::config(project_root).exists() {
+            Message::new(MessageType::Info, "Detected JavaScript project...").print();
+            tracing::info!("Detected JavaScript project.");
+            Some(Type::JavaScript(JavaScript {}))
+        } else {
             Message::new(MessageType::Warning, "Could not identify project type...").print();
             tracing::warn!("Could not identify project type...");
-            return None;
-        };
-        Some(project)
+            None
+        }
     }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Type {
+    Rust(Rust),
+    JavaScript(JavaScript),
 }

--- a/src/config/project/rust.rs
+++ b/src/config/project/rust.rs
@@ -1,0 +1,33 @@
+use axoasset::Asset;
+
+use crate::config::ProjectConfig;
+use crate::errors::*;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+static CARGO_TOML: &str = "./Cargo.toml";
+
+#[derive(Debug, Deserialize)]
+struct CargoToml {
+    package: ProjectConfig,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Rust {}
+impl Rust {
+    pub fn read(&self, project_root: &Option<PathBuf>) -> Result<ProjectConfig> {
+        let path = Rust::config(project_root);
+        let cargo_toml_future = Asset::load_string(path.to_str().unwrap());
+        let cargo_toml = tokio::runtime::Handle::current().block_on(cargo_toml_future)?;
+        let data: CargoToml = toml::from_str(&cargo_toml)?;
+        Ok(data.package)
+    }
+
+    pub fn config(project_root: &Option<PathBuf>) -> PathBuf {
+        if let Some(root) = project_root {
+            Path::new(root).join(CARGO_TOML)
+        } else {
+            Path::new(CARGO_TOML).to_path_buf()
+        }
+    }
+}

--- a/src/site/artifacts/mod.rs
+++ b/src/site/artifacts/mod.rs
@@ -2,7 +2,6 @@ use crate::config::Config;
 use crate::data::cargo_dist::DistRelease;
 use crate::data::Context;
 use crate::errors::*;
-use crate::message::{Message, MessageType};
 
 mod installers;
 mod package_managers;
@@ -26,18 +25,15 @@ pub fn page(context: &Context, config: &Config) -> Result<String> {
     let artifacts = &config.artifacts;
     let release = &context.latest_dist_release;
 
-    let (installer_list, artifact_table) = if let Some(release) =
-        has_valid_setup(artifacts.cargo_dist, release)
-    {
-        (
-            Some(installers::build_list(&release, config)?),
-            Some(table::build(release, config)?),
-        )
-    } else {
-        let msg = "You have indicated that you use cargo dist but we could not find a cargo dist release for your project. We are continuing to build your site, but it will not include artifact features.";
-        Message::new(MessageType::Warning, msg).print();
-        (None, None)
-    };
+    let (installer_list, artifact_table) =
+        if let Some(release) = has_valid_setup(artifacts.cargo_dist, release) {
+            (
+                Some(installers::build_list(&release, config)?),
+                Some(table::build(release, config)?),
+            )
+        } else {
+            (None, None)
+        };
 
     let package_manager_list = artifacts
         .package_managers

--- a/tests/config/fixtures/project_config.rs
+++ b/tests/config/fixtures/project_config.rs
@@ -8,14 +8,6 @@ pub fn cargo_toml() -> &'static str {
     "#
 }
 
-pub fn main_rs() -> &'static str {
-    r#"
-fn main() {
-    println!("hello world!);
-}
-    "#
-}
-
 pub fn package_json() -> &'static str {
     r#"
 {

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -80,3 +80,16 @@ fn it_loads_a_rust_project_config() {
         .close()
         .expect("could not successfully delete temporary directory");
 }
+
+#[test]
+fn it_can_successfully_not_detect_a_project() {
+    let tempdir = assert_fs::TempDir::new().expect("failed creating tempdir");
+
+    assert_eq!(
+        ProjectConfig::detect(&Some(tempdir.path().to_path_buf())),
+        None
+    );
+    tempdir
+        .close()
+        .expect("could not successfully delete temporary directory");
+}

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -2,7 +2,7 @@ mod fixtures;
 use super::utils::tokio_utils::TEST_RUNTIME;
 use fixtures::project_config;
 
-use oranda::config::project::ProjectConfig;
+use oranda::config::project::{JavaScript, ProjectConfig, Rust, Type};
 
 use assert_fs::fixture::{FileWriteStr, PathChild};
 
@@ -15,10 +15,8 @@ fn it_detects_a_js_project() {
         .expect("failed to write package_json");
 
     assert_eq!(
-        ProjectConfig::get_project(&Some(tempdir.path().to_path_buf()))
-            .unwrap()
-            .kind,
-        axoproject::WorkspaceKind::Javascript
+        ProjectConfig::detect(&Some(tempdir.path().to_path_buf())),
+        Some(Type::JavaScript(JavaScript {}))
     );
     tempdir
         .close()
@@ -53,14 +51,10 @@ fn it_detects_a_rust_project() {
     cargo_toml
         .write_str(project_config::cargo_toml())
         .expect("failed to write cargo toml");
-    let main = tempdir.child("src/main.rs");
-    main.write_str(project_config::main_rs())
-        .expect("failed to write main.rs");
+
     assert_eq!(
-        ProjectConfig::get_project(&Some(tempdir.path().to_path_buf()))
-            .unwrap()
-            .kind,
-        axoproject::WorkspaceKind::Rust
+        ProjectConfig::detect(&Some(tempdir.path().to_path_buf())),
+        Some(Type::Rust(Rust {}))
     );
     tempdir
         .close()
@@ -75,9 +69,6 @@ fn it_loads_a_rust_project_config() {
     cargo_toml
         .write_str(project_config::cargo_toml())
         .expect("failed to write cargo toml");
-    let main = tempdir.child("src/main.rs");
-    main.write_str(project_config::main_rs())
-        .expect("failed to write main.rs");
     let config = ProjectConfig::load(Some(tempdir.path().to_path_buf()))
         .expect("failed to load Cargo.toml")
         .unwrap();


### PR DESCRIPTION
this PR pulls out axoproject for the moment and reverts to the previous project config logic because axoproject was panicing  on non js/non rust projects. the transition is easy enough and we can reintegrate axoproject once we have a little more sync time