### PR TITLE
add 'text' as an alias for 'txt' in markdown

### DIFF
--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -65,6 +65,7 @@ pub fn syntax_highlight(
     let theme_set = ThemeSet { themes };
     let language = match lang {
         None | Some("") => "rs",
+        Some("text") => "txt",
         Some(l) => l,
     };
     let syntax = find_syntax(&ps, language)?;


### PR DESCRIPTION
This is a super standard convention in the rust ecosystem because defaulting to rust requires a way to say 'no for reals its just text don't do anything fancy'.