### PR TITLE
feat(mdbook): clean up mdbook integration

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -60,21 +60,7 @@ jobs:
           toolchain: stable
           override: true
 
-      # OPTIONAL: build your mdbook
-      # Note that "./docs/" is the directory in our repo where the book.toml is
-      # and we pass that to mdbook. You also need to tell oranda.json this with
-      #   "md_book": "./docs/book/" 
-      # ("book" being the dir where mdbook writes is output)
-      - name: Install mdbook
-        run: |
-          mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.14/mdbook-v0.4.14-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-          echo `pwd`/mdbook >> $GITHUB_PATH
-      - name: Run mdbook build
-        run: |
-          mdbook build docs
-      
-      # Install and run oranda
+      # Install and run oranda (and mdbook)
       # This will write all output to ./public/ (including copying mdbook's output to there)
       - name: Install and run oranda
         # Install from this checkout because WE'RE ORANDA

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,8 +524,18 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
+ "once_cell",
  "strsim",
  "terminal_size 0.2.6",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1594fe2312ec4abf402076e407628f5c313e54c32ade058521df4ee34ecac8a8"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -836,6 +852,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1168,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "4.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c3372087601b532857d332f5957cbae686da52bb7810bf038c3e3c3cc2fa0d"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1288,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1600,6 +1649,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "mdbook"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764dcbfc2e5f868bc1b566eb179dff1a06458fd0cff846aae2579392dd3f01a0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "clap_complete",
+ "env_logger",
+ "handlebars",
+ "log",
+ "memchr",
+ "once_cell",
+ "opener",
+ "pulldown-cmark",
+ "regex",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tempfile",
+ "toml",
+ "topological-sort",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,6 +1901,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "opener"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293c15678e37254c15bd2f092314abb4e51d7fdde05c2021279c12631b54f005"
+dependencies = [
+ "bstr",
+ "winapi",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1975,7 @@ dependencies = [
  "futures-util",
  "lazy_static",
  "linked-hash-map",
+ "mdbook",
  "miette",
  "minifier",
  "reqwest",
@@ -1969,6 +2055,50 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -2136,6 +2266,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -2532,6 +2673,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2999,6 +3146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,6 +3291,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ camino = "1.1.4"
 axocli = "0.1.0"
 miette = "5.7.0"
 futures-util = "0.3.28"
+mdbook = { version = "0.4.17", default-features = false }
 
 [dev-dependencies]
 assert_cmd="2"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -3,3 +3,6 @@ authors = ["axodotdev"]
 language = "en"
 multilingual = false
 src = "src"
+
+[output.markdown]
+[output.html]

--- a/oranda.json
+++ b/oranda.json
@@ -2,7 +2,7 @@
   "favicon": "https://www.axo.dev/favicon.ico",
   "path_prefix": "oranda",
   "mdbook": {
-    "path": "./docs/",
+    "path": "./docs",
     "theme": true
   },
   "changelog": true,

--- a/oranda.json
+++ b/oranda.json
@@ -1,7 +1,10 @@
 {
   "favicon": "https://www.axo.dev/favicon.ico",
   "path_prefix": "oranda",
-  "md_book": "./docs/book/",
+  "mdbook": {
+    "path": "./docs/",
+    "theme": true
+  },
   "changelog": true,
   "social": {
     "image": "https://www.axo.dev/meta_small.jpeg",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 
 use theme::Theme;
 
-pub use self::oranda::BookConfig;
+pub use self::oranda::MdBookConfig;
 
 #[derive(Debug)]
 pub struct Config {
@@ -40,7 +40,7 @@ pub struct Config {
     pub path_prefix: Option<String>,
     pub license: Option<String>,
     /// The config for using mdbook
-    pub md_book: Option<BookConfig>,
+    pub mdbook: Option<MdBookConfig>,
     pub changelog: bool,
 }
 
@@ -106,7 +106,7 @@ impl Config {
                     logo: custom.logo,
                     favicon: custom.favicon,
                     path_prefix: custom.path_prefix,
-                    md_book: None,
+                    mdbook: None,
                     changelog: custom.changelog.unwrap_or(default.changelog),
                 });
             // otherwise both oranda config and project manifest exists
@@ -141,7 +141,7 @@ impl Config {
                     logo: custom.logo,
                     favicon: custom.favicon,
                     path_prefix: custom.path_prefix,
-                    md_book: custom.md_book,
+                    mdbook: custom.mdbook,
                     changelog: custom.changelog.unwrap_or(default.changelog),
                 });
             }
@@ -190,7 +190,7 @@ impl Default for Config {
             favicon: None,
             path_prefix: None,
             static_dir: String::from("static"),
-            md_book: None,
+            mdbook: None,
             changelog: false,
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,8 @@ use std::collections::HashMap;
 
 use theme::Theme;
 
+pub use self::oranda::BookConfig;
+
 #[derive(Debug)]
 pub struct Config {
     pub description: String,
@@ -37,7 +39,8 @@ pub struct Config {
     pub favicon: Option<String>,
     pub path_prefix: Option<String>,
     pub license: Option<String>,
-    pub md_book: Option<String>,
+    /// The config for using mdbook
+    pub md_book: Option<BookConfig>,
     pub changelog: bool,
 }
 
@@ -103,7 +106,7 @@ impl Config {
                     logo: custom.logo,
                     favicon: custom.favicon,
                     path_prefix: custom.path_prefix,
-                    md_book: custom.md_book,
+                    md_book: None,
                     changelog: custom.changelog.unwrap_or(default.changelog),
                 });
             // otherwise both oranda config and project manifest exists

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -21,7 +21,7 @@ pub struct Social {
 
 /// Config for us bulding and integrating your mdbook
 #[derive(Debug, Deserialize)]
-pub struct BookConfig {
+pub struct MdBookConfig {
     /// Path to the mdbook
     pub path: String,
     /// Whether to enable the custom oranda/axo theme
@@ -51,8 +51,8 @@ pub struct OrandaConfig {
     pub path_prefix: Option<String>,
     pub license: Option<String>,
     /// Config for mdbook
-    #[serde(alias = "mdbook")]
-    pub md_book: Option<BookConfig>,
+    #[serde(alias = "md_book")]
+    pub mdbook: Option<MdBookConfig>,
     pub changelog: Option<bool>,
 }
 

--- a/src/config/oranda.rs
+++ b/src/config/oranda.rs
@@ -19,6 +19,15 @@ pub struct Social {
     pub twitter_account: Option<String>,
 }
 
+/// Config for us bulding and integrating your mdbook
+#[derive(Debug, Deserialize)]
+pub struct BookConfig {
+    /// Path to the mdbook
+    pub path: String,
+    /// Whether to enable the custom oranda/axo theme
+    pub theme: Option<bool>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct OrandaConfig {
     pub description: Option<String>,
@@ -41,7 +50,9 @@ pub struct OrandaConfig {
     pub favicon: Option<String>,
     pub path_prefix: Option<String>,
     pub license: Option<String>,
-    pub md_book: Option<String>,
+    /// Config for mdbook
+    #[serde(alias = "mdbook")]
+    pub md_book: Option<BookConfig>,
     pub changelog: Option<bool>,
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,7 +70,7 @@ pub enum OrandaError {
         details: miette::Report,
     },
 
-    #[error("Could not find a build in {dist_dir}.")]
+    #[error("Could not find a build in {dist_dir}")]
     #[diagnostic(help("Did you remember to run `oranda build`?"))]
     BuildNotFound { dist_dir: String },
 
@@ -86,6 +86,18 @@ pub enum OrandaError {
         url: String,
         #[source]
         details: reqwest::Error,
+    },
+
+    #[error("Couldn't load your mdbook at {path}")]
+    MdBookLoad {
+        path: String,
+        inner: mdbook::errors::Error,
+    },
+
+    #[error("Couldn't build your mdbook at {path}")]
+    MdBookBuild {
+        path: String,
+        inner: mdbook::errors::Error,
     },
 
     #[error("{0}")]

--- a/src/site/layout/header.rs
+++ b/src/site/layout/header.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::config::artifacts::Artifacts;
-use crate::config::Config;
+use crate::config::{BookConfig, Config};
 use crate::errors::*;
 use crate::message::{Message, MessageType};
 use crate::site::{link, page};
@@ -32,7 +32,7 @@ fn nav(
     additional_pages: &Option<HashMap<String, String>>,
     path_prefix: &Option<String>,
     artifacts: &Artifacts,
-    md_book: &Option<String>,
+    md_book: &Option<BookConfig>,
     changelog: &bool,
 ) -> Result<Box<nav<String>>> {
     Message::new(MessageType::Info, "Building nav...").print();

--- a/src/site/layout/header.rs
+++ b/src/site/layout/header.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::config::artifacts::Artifacts;
-use crate::config::{BookConfig, Config};
+use crate::config::{Config, MdBookConfig};
 use crate::errors::*;
 use crate::message::{Message, MessageType};
 use crate::site::{link, page};
@@ -32,7 +32,7 @@ fn nav(
     additional_pages: &Option<HashMap<String, String>>,
     path_prefix: &Option<String>,
     artifacts: &Artifacts,
-    md_book: &Option<BookConfig>,
+    md_book: &Option<MdBookConfig>,
     changelog: &bool,
 ) -> Result<Box<nav<String>>> {
     Message::new(MessageType::Info, "Building nav...").print();
@@ -111,14 +111,14 @@ pub fn create(config: &Config) -> Result<Box<header<String>>> {
 
     let nav = if config.additional_pages.is_some()
         || config.artifacts.has_some()
-        || config.md_book.is_some()
+        || config.mdbook.is_some()
         || config.changelog
     {
         Some(nav(
             &config.additional_pages,
             &config.path_prefix,
             &config.artifacts,
-            &config.md_book,
+            &config.mdbook,
             &config.changelog,
         )?)
     } else {


### PR DESCRIPTION
* config is now called 'mdbook' instead of 'md_book'
* config is now an Object that takes 'path' to the root dir of the book
* we will now build your mdbook for you as part of oranda build
* we will now properly handle when you have multiple renderers (finding the html output)

future work will introduce integrated theme support

fixes #315 
fixes #311
fixes #287 