### PR TITLE
cleanup cargo-dist manifest fetching/selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1039,7 @@ checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1875,6 +1887,7 @@ dependencies = [
  "comrak",
  "console",
  "fs_extra",
+ "futures-util",
  "lazy_static",
  "linked-hash-map",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ url = "2.3.1"
 camino = "1.1.4"
 axocli = "0.1.0"
 miette = "5.7.0"
+futures-util = "0.3.28"
 
 [dev-dependencies]
 assert_cmd="2"

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -90,8 +90,10 @@ impl Context {
         // that don't use cargo-dist, we're going to prefer the cargo-dist one, but we should
         // warn the user that things are wonky
         if latest_dist_release.is_some() && latest_dist_release != latest_stable_release {
-            let msg = "You have newer stable Github Releases than your latest cargo-dist Release. Is this intended? (We're going to prefer the cargo-dist one.)";
-            Message::new(MessageType::Warning, msg).print();
+            let dist_rel = &all[latest_dist_prerelease.unwrap()].source.tag_name;
+            let stable_rel = &all[latest_stable_release.unwrap()].source.tag_name;
+            let msg = format!("You have newer stable Github Releases ({}) than your latest cargo-dist Release ({}). Is this intended? (We're going to prefer the cargo-dist one.)", stable_rel, dist_rel);
+            Message::new(MessageType::Warning, &msg).print();
         }
 
         // If we found a stable dist release, use that

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -33,35 +33,77 @@ impl Context {
         cargo_dist: bool,
     ) -> Result<(Vec<Release>, bool, Option<DistRelease>)> {
         let gh_releases = GithubRelease::fetch_all(repo)?;
+        let all =
+            tokio::runtime::Handle::current().block_on(futures_util::future::try_join_all(
+                gh_releases
+                    .into_iter()
+                    .map(|gh_release| Release::new(gh_release, cargo_dist)),
+            ))?;
+
         let mut has_prereleases = false;
-        let mut found_latest_dist_release = false;
         let mut warned = false;
         let mut latest_dist_release = None;
-        let mut all = vec![];
-        for gh_release in gh_releases {
-            if gh_release.prerelease && !has_prereleases {
-                let msg = "Detected pre-releases...";
-                Message::new(MessageType::Info, msg).print();
-                has_prereleases = true
+        let mut latest_dist_prerelease = None;
+        let mut latest_stable_release = None;
+
+        for (idx, release) in all.iter().enumerate() {
+            let is_prerelease = release.source.prerelease;
+            // Make note of whether we've found prereleases or stable releases yet
+            if is_prerelease {
+                if !has_prereleases {
+                    let msg = "Detected pre-releases...";
+                    Message::new(MessageType::Info, msg).print();
+                    has_prereleases = true;
+                }
+            } else if latest_stable_release.is_none() {
+                latest_stable_release = Some(idx);
             }
-            if !found_latest_dist_release && gh_release.has_dist_manifest() {
+
+            // Special handling of dist-manifest.json
+            if release.manifest.is_some() {
                 if cargo_dist {
-                    let release = Release::new(gh_release.clone(), cargo_dist)?;
-                    if let Some(manifest) = release.manifest {
-                        latest_dist_release = Some(DistRelease {
-                            manifest,
-                            source: gh_release.clone(),
-                        });
+                    // cargo-dist is enabled, so we want to find the latest stable release
+                    // or, failing that, the latest prerelease.
+                    if is_prerelease {
+                        if latest_dist_prerelease.is_none() && latest_dist_release.is_none() {
+                            latest_dist_prerelease = Some(idx);
+                        }
+                    } else if latest_dist_release.is_none() {
+                        latest_dist_release = Some(idx);
                     }
-                    found_latest_dist_release = latest_dist_release.is_some();
                 } else if !warned {
+                    // We found a dist-manifest but they didn't enable cargo-dist support, encourage them to do so
                     let msg = "You have not configured cargo-dist yet we detected dist-manifests in your releases. Is this intended?";
                     Message::new(MessageType::Warning, msg).print();
                     warned = true;
                 }
             }
-            all.push(Release::new(gh_release, cargo_dist)?)
         }
-        Ok((all, has_prereleases, latest_dist_release))
+
+        // If we found any kind of stable release, then throw out any prerelease fallbacks.
+        // This prevents us recommending an unstable dist-release over a stable non-dist-release.
+        if latest_stable_release.is_some() {
+            latest_dist_prerelease = None;
+        }
+
+        // If we found a stable cargo-dist release, but there's even newer stable releases
+        // that don't use cargo-dist, we're going to prefer the cargo-dist one, but we should
+        // warn the user that things are wonky
+        if latest_dist_release.is_some() && latest_dist_release != latest_stable_release {
+            let msg = "You have newer stable Github Releases than your latest cargo-dist Release. Is this intended? (We're going to prefer the cargo-dist one.)";
+            Message::new(MessageType::Warning, msg).print();
+        }
+
+        // If we found a stable dist release, use that
+        // otherwise use an unstable one, if we found it
+        let dist_release = latest_dist_release.or(latest_dist_prerelease).map(|idx| {
+            let release = &all[idx];
+            DistRelease {
+                manifest: release.manifest.as_ref().unwrap().clone(),
+                source: release.source.clone(),
+            }
+        });
+
+        Ok((all, has_prereleases, dist_release))
     }
 }

--- a/src/data/release.rs
+++ b/src/data/release.rs
@@ -11,9 +11,9 @@ pub struct Release {
 }
 
 impl Release {
-    pub fn new(gh_release: GithubRelease, cargo_dist: bool) -> Result<Self> {
+    pub async fn new(gh_release: GithubRelease, cargo_dist: bool) -> Result<Self> {
         let manifest = if cargo_dist {
-            Self::fetch_manifest(gh_release.asset_url(cargo_dist::MANIFEST_FILENAME))?
+            Self::fetch_manifest(gh_release.asset_url(cargo_dist::MANIFEST_FILENAME)).await?
         } else {
             None
         };
@@ -23,10 +23,10 @@ impl Release {
         })
     }
 
-    fn fetch_manifest(url: Option<&str>) -> Result<Option<DistManifest>> {
+    async fn fetch_manifest(url: Option<&str>) -> Result<Option<DistManifest>> {
         if let Some(manifest_url) = url {
-            match reqwest::blocking::get(manifest_url)?.error_for_status() {
-                Ok(resp) => match resp.json::<DistManifest>() {
+            match reqwest::get(manifest_url).await?.error_for_status() {
+                Ok(resp) => match resp.json::<DistManifest>().await {
                     Ok(manifest) => Ok(Some(manifest)),
                     Err(e) => {
                         let msg = format!("Failed to parse dist-manifest at {manifest_url}.\nDetails:{e}\n\nSkipping...");


### PR DESCRIPTION
This makes Release::new async so that we can fetch all Github Releases in parallel.

Because I needed to rework the loop already, I took the time to introduce more robust logic for selecting the 'latest' dist release, in a way that's more aware of non-dist-releases and prereleases.

fixes #302 