### PR TITLE
map 'shell' to 'sh' in syntax

### DIFF
--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -66,6 +66,7 @@ pub fn syntax_highlight(
     let language = match lang {
         None | Some("") => "rs",
         Some("text") => "txt",
+        Some("shell") => "sh",
         Some(l) => l,
     };
     let syntax = find_syntax(&ps, language)?;


### PR DESCRIPTION
although cargo-dist no longer emits this, it's Annoying to complain about legacy releases