### PR TITLE
feat(fast-installer): memoize installer fetches by checking if we've …

### DIFF
--- a/src/data/cargo_dist.rs
+++ b/src/data/cargo_dist.rs
@@ -1,4 +1,5 @@
 use axoasset::{Asset, LocalAsset};
+use camino::Utf8PathBuf;
 pub use cargo_dist_schema::{Artifact, ArtifactKind, DistManifest, Release};
 
 use crate::config::Config;
@@ -23,12 +24,16 @@ pub fn get_os(name: &str) -> Option<&str> {
     }
 }
 
+/// Make the source of an installer script available on the server
 pub fn write_installer_source(config: &Config, name: &str, version: &str) -> Result<String> {
-    let download_link = download_link(config, name, version)?;
-    let file_string_future = Asset::load_string(download_link.as_str());
-    let file_string = tokio::runtime::Handle::current().block_on(file_string_future)?;
     let file_path = format!("{}.txt", &name);
-    LocalAsset::write_new(&file_string, &file_path, &config.dist_dir)?;
+    let full_file_path = Utf8PathBuf::from(&config.dist_dir).join(&file_path);
+    if !full_file_path.exists() {
+        let download_link = download_link(config, name, version)?;
+        let file_string_future = Asset::load_string(download_link.as_str());
+        let file_string = tokio::runtime::Handle::current().block_on(file_string_future)?;
+        LocalAsset::write_new(&file_string, &file_path, &config.dist_dir)?;
+    }
     Ok(file_path)
 }
 

--- a/src/site/artifacts/installers.rs
+++ b/src/site/artifacts/installers.rs
@@ -101,19 +101,23 @@ fn build_install_block_for_installer(
     let install_code = build_install_hint_code(data, config)?;
 
     let copy_icon = icons::copy();
-    let hint = get_install_hint(data, config)?;
+    let (copy, src) = get_install_hint(data, config)?;
+
+    let view_source = src.map(|src| {
+        html!(<a class="button primary button" href=(src)>
+                {text!("Source")}
+        </a>)
+    });
 
     Ok(html!(
         <div class="install-code-wrapper">
             {unsafe_text!(install_code)}
             <button
-                data-copy={hint.0}
+                data-copy={copy}
                 class="button primary copy-clipboard-button button">
                 {copy_icon}
             </button>
-            <a class="button primary button" href=(hint.1)>
-                {text!("Source")}
-            </a>
+            {view_source}
         </div>
     ))
 }
@@ -180,7 +184,7 @@ fn build_install_hint_code(data: &InstallerData, config: &Config) -> Result<Stri
     }
 }
 
-fn get_install_hint(data: &InstallerData, config: &Config) -> Result<(String, String)> {
+fn get_install_hint(data: &InstallerData, config: &Config) -> Result<(String, Option<String>)> {
     let hint = data
         .app
         .artifacts
@@ -196,8 +200,15 @@ fn get_install_hint(data: &InstallerData, config: &Config) -> Result<(String, St
 
     if let Some(current_hint) = hint {
         if let (Some(install_hint), Some(name)) = (&current_hint.install_hint, &current_hint.name) {
-            let file_path =
-                cargo_dist::write_installer_source(config, name, &data.app.app_version)?;
+            let file_path = if name.ends_with(".sh") || name.ends_with(".ps1") {
+                Some(cargo_dist::write_installer_source(
+                    config,
+                    name,
+                    &data.app.app_version,
+                )?)
+            } else {
+                None
+            };
             return Ok((install_hint.to_string(), file_path));
         }
     }


### PR DESCRIPTION
…already downloaded them

also this limits the code to sh/ps1 to avoid fetching binary installers