### PR TITLE
prefix tags before shoving them in html ids

### DIFF
--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -87,7 +87,8 @@ pub fn build_page_preview(
     let tag_name = &release.source.tag_name;
     let title = release.source.name.as_ref().unwrap_or(tag_name);
 
-    let id: axohtml::types::Id = axohtml::types::Id::new(tag_name.clone());
+    // We need to prefix the id with `tag-` to not break on things like "0.14.0" (no v prefix)
+    let id: axohtml::types::Id = axohtml::types::Id::new(format!("tag-{tag_name}"));
     let formatted_date = match DateTime::parse_from_rfc3339(&release.source.published_at) {
         Ok(date) => date.format("%b %e %Y at %R UTC").to_string(),
         Err(_) => release.source.published_at.to_owned(),


### PR DESCRIPTION
This is required to handle the rust-minidump repo, which has some old unprefixed versions