### PR TITLE
make the path we pass to mdbook absolute to prevent plugins like link…

### DIFF
--- a/docs/src/configuration/syntax-theme.md
+++ b/docs/src/configuration/syntax-theme.md
@@ -1,6 +1,6 @@
 # Syntax Theme
 
-When it comes to syntax highlighting by default oranda will use the [`material-theme`](./themes/themes.html#materialtheme) and can be easily changed for any of the default themes that can be seen in the [Available themes page](./themes/themes).
+When it comes to syntax highlighting by default oranda will use the [`material-theme`](./theme.md#materialtheme) and can be easily changed for any of the default themes that can be seen in the [Available themes page](./theme.md).
 
 ```json
 {

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -177,9 +177,11 @@ impl Site {
         tracing::info!("Building mdbook...");
 
         // Read mdbook's config to find the right dirs
-        let book_path = &book_cfg.path;
-        let md = mdbook::MDBook::load(book_path).map_err(|e| OrandaError::MdBookLoad {
-            path: book_path.clone(),
+
+        let cur_dir = axoasset::LocalAsset::current_dir()?;
+        let book_path = cur_dir.join(&book_cfg.path);
+        let md = mdbook::MDBook::load(&book_path).map_err(|e| OrandaError::MdBookLoad {
+            path: book_path.to_string(),
             inner: e,
         })?;
         let build_dir =
@@ -187,7 +189,7 @@ impl Site {
 
         // Build the mdbook
         md.build().map_err(|e| OrandaError::MdBookBuild {
-            path: book_path.clone(),
+            path: book_path.to_string(),
             inner: e,
         })?;
 


### PR DESCRIPTION
…check from freaking out

no idea why this happens. also this is kinda a hacky fix, we should probably do this transform at the time we make the config so that it's relative to oranda.json, and not the cwd.

wanted to put this up before i forget.