### PR TITLE
feat: add watch functionality to dev command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1625,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1728,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags",
+ "libc",
 ]
 
 [[package]]
@@ -2046,6 +2095,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d9ba6c734de18ca27c8cef5cd7058aa4ac9f63596131e4c7e41e579319032a2"
+dependencies = [
+ "bitflags",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2284,7 @@ dependencies = [
  "mdbook",
  "miette",
  "minifier",
+ "notify",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ axocli = "0.1.0"
 miette = "5.7.0"
 futures-util = "0.3.28"
 mdbook = { version = "0.4.17", default-features = false }
+notify = "6.0.0"
 
 [dev-dependencies]
 assert_cmd="2"

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -76,10 +76,9 @@ impl Dev {
 
         // Watch for the mdbook directory, if we have it
         if config.mdbook.is_some() {
-            // FIXME: We generate the mdbook html content in a subfolder of this folder, which means we can't watch
-            // the folder recursively with `notify`. This breaks usage for users who use a nested mdbook docs structure,
-            // and it's something we should handle.
-            paths_to_watch.push(config.mdbook.unwrap().path);
+            let mut source_path = PathBuf::from(config.mdbook.unwrap().path);
+            source_path.push("src");
+            paths_to_watch.push(source_path.display().to_string());
         }
 
         // Watch for any project manifest files
@@ -114,6 +113,7 @@ impl Dev {
 
         for path in paths_to_watch {
             let path = PathBuf::from(path);
+            // FIXME: Allow users to recursively watch directories!
             watcher.watch(path.as_path(), notify::RecursiveMode::NonRecursive)?;
         }
 

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -76,16 +76,9 @@ impl Dev {
 
         // Watch for the mdbook directory, if we have it
         if config.mdbook.is_some() {
-<<<<<<< HEAD
             let mut source_path = PathBuf::from(config.mdbook.unwrap().path);
             source_path.push("src");
             paths_to_watch.push(source_path.display().to_string());
-=======
-            // FIXME: We generate the mdbook html content in a subfolder of this folder, which means we can't watch
-            // the folder recursively with `notify`. This breaks usage for users who use a nested mdbook docs structure,
-            // and it's something we should handle.
-            paths_to_watch.push(config.mdbook.unwrap().path);
->>>>>>> 6513910312f39b6750a0ba1f08d292ce6f2985d1
         }
 
         // Watch for any project manifest files

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -25,6 +25,9 @@ pub struct Dev {
     /// Skip the first build before starting to watch for changes
     #[arg(long)]
     no_first_build: bool,
+    /// List of extra paths to watch
+    #[arg(short, long)]
+    include_paths: Option<Vec<Utf8PathBuf>>,
 }
 
 impl Dev {
@@ -53,13 +56,21 @@ impl Dev {
                 .into(),
         );
 
+        // Watch for any user-provided paths
+        if self.include_paths.is_some() {
+            let mut include_paths: Vec<String> = self
+                .include_paths
+                .unwrap()
+                .iter()
+                .map(|p| p.to_string())
+                .collect();
+            paths_to_watch.append(&mut include_paths);
+        }
+
         // Watch for additional pages, if we have any
         if config.additional_pages.is_some() {
-            let mut additional_pages: Vec<String> = config
-                .additional_pages
-                .unwrap().values()
-                .cloned()
-                .collect();
+            let mut additional_pages: Vec<String> =
+                config.additional_pages.unwrap().values().cloned().collect();
             paths_to_watch.append(&mut additional_pages);
         }
 

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -1,22 +1,139 @@
+use std::path::PathBuf;
+
+use axoproject::WorkspaceSearch;
 use camino::Utf8PathBuf;
 use clap::Parser;
+use notify::{event::ModifyKind, EventKind, Watcher};
 
-use crate::commands::{Build, Serve};
-use oranda::errors::*;
+use crate::{
+    commands::{Build, Serve},
+    message::{Message, MessageType},
+};
+use oranda::{config::Config, errors::*};
 
 #[derive(Clone, Debug, Parser)]
 pub struct Dev {
+    /// The port for the file server to be launched on
     #[arg(long)]
     port: Option<u16>,
+    /// The project root we want to build from
     #[arg(long)]
     project_root: Option<Utf8PathBuf>,
+    /// Custom path to an oranda configuration file
     #[arg(long)]
     config_path: Option<Utf8PathBuf>,
+    /// Skip the first build before starting to watch for changes
+    #[arg(long)]
+    no_first_build: bool,
 }
 
 impl Dev {
     pub fn run(self) -> Result<()> {
-        Build::new(self.project_root.clone(), self.config_path.clone()).run()?;
-        Serve::new(self.port).run()
+        Message::new(
+            MessageType::Info,
+            "Starting dev, looking for paths to watch...",
+        )
+        .print();
+        tracing::info!("Starting dev, looking for paths to watch...");
+
+        let config = Config::build(
+            &self
+                .config_path
+                .clone()
+                .unwrap_or(Utf8PathBuf::from("./oranda.json")),
+        )?;
+        let mut paths_to_watch = vec![];
+        // Watch for the readme file
+        paths_to_watch.push(config.readme_path);
+        // Watch for the oranda config file
+        paths_to_watch.push(
+            self.config_path
+                .clone()
+                .unwrap_or(Utf8PathBuf::from("./oranda.json"))
+                .into(),
+        );
+
+        // Watch for additional pages, if we have any
+        if config.additional_pages.is_some() {
+            let mut additional_pages: Vec<String> = config
+                .additional_pages
+                .unwrap().values()
+                .cloned()
+                .collect();
+            paths_to_watch.append(&mut additional_pages);
+        }
+
+        // Watch for the mdbook directory, if we have it
+        if config.mdbook.is_some() {
+            // FIXME: We generate the mdbook html content in a subfolder of this folder, which means we can't watch
+            // the folder recursively with `notify`. This breaks usage for users who use a nested mdbook docs structure,
+            // and it's something we should handle.
+            paths_to_watch.push(config.mdbook.unwrap().path);
+        }
+
+        // Watch for any project manifest files
+        let project = axoproject::get_workspaces("./".into(), None);
+        if let WorkspaceSearch::Found(workspace) = project.rust {
+            paths_to_watch.push(workspace.manifest_path.into());
+        }
+        if let WorkspaceSearch::Found(workspace) = project.javascript {
+            paths_to_watch.push(workspace.manifest_path.into());
+        }
+
+        Message::new(
+            MessageType::Info,
+            &format!(
+                "Found {} paths to watch, starting watch...",
+                paths_to_watch.len()
+            ),
+        )
+        .print();
+        tracing::info!(
+            "Found {} paths to watch, starting watch...",
+            paths_to_watch.len()
+        );
+        Message::new(
+            MessageType::Debug,
+            &format!("Files watched: {:?}", paths_to_watch),
+        )
+        .print();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut watcher = notify::RecommendedWatcher::new(tx, notify::Config::default())?;
+
+        for path in paths_to_watch {
+            let path = PathBuf::from(path);
+            watcher.watch(path.as_path(), notify::RecursiveMode::NonRecursive)?;
+        }
+
+        if !self.no_first_build {
+            Build::new(self.project_root.clone(), self.config_path.clone()).run()?;
+        }
+        // Spawn the serve process out into a separate thread so that we can loop through received events on this thread
+        let _ = std::thread::spawn(move || Serve::new(self.port).run());
+        for res in rx {
+            match res {
+                Ok(event) => {
+                    // We only care about content or name changes, not metadata
+                    if let EventKind::Modify(ModifyKind::Metadata(_)) = event.kind {
+                        continue;
+                    }
+                    Message::new(
+                        MessageType::Info,
+                        &format!("Path(s) {:?} changed, rebuilding...", event.paths),
+                    )
+                    .print();
+
+                    Build::new(self.project_root.clone(), self.config_path.clone())
+                        .run()
+                        .unwrap();
+                }
+                Err(err) => {
+                    // FIXME: Do we want to do something other than panicking?
+                    panic!("Error while watching for filesystem changes: {:?}", err);
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/src/config/oranda_config.rs
+++ b/src/config/oranda_config.rs
@@ -19,7 +19,7 @@ pub struct Social {
     pub twitter_account: Option<String>,
 }
 
-/// Config for us bulding and integrating your mdbook
+/// Config for us building and integrating your mdbook
 #[derive(Debug, Deserialize)]
 pub struct MdBookConfig {
     /// Path to the mdbook

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -109,6 +109,10 @@ pub enum OrandaError {
         cause: axoproject::errors::AxoprojectError,
     },
 
+    #[error("We were unable to watch your filesystem for changes")]
+    #[diagnostic(help = "Make sure that oranda has privileges to set up file watchers!")]
+    FilesystemWatchError(#[from] notify::Error),
+
     #[error("{0}")]
     Other(String),
 }


### PR DESCRIPTION
Files that we watch by default:

- `oranda.json` or custom config path
- Readme file (either default or overriden in config)
- mdbook directory (currently not recursively as the HTML output gets put in that directory too)
- Additional pages as specified in the config
- Project manifest files as found by `axoproject`
- User-supplied paths in the `-i, --include-paths` CLI argument