### PR TITLE
fix a bug and improve error message when serializing github releases data 

### DIFF
--- a/src/data/github/mod.rs
+++ b/src/data/github/mod.rs
@@ -1,5 +1,6 @@
 use crate::errors::*;
 
+use axoasset::SourceFile;
 use reqwest::{blocking::Response, header::USER_AGENT};
 use serde::{Deserialize, Serialize};
 
@@ -82,7 +83,7 @@ impl GithubRelease {
 
     fn parse_response(response: reqwest::blocking::Response) -> Result<Vec<GithubRelease>> {
         match response.error_for_status() {
-            Ok(r) => match r.json() {
+            Ok(r) => match SourceFile::new("", r.text()?).deserialize_json() {
                 Ok(releases) => Ok(releases),
                 Err(e) => Err(OrandaError::GithubReleaseParseError { details: e }),
             },

--- a/src/data/github/mod.rs
+++ b/src/data/github/mod.rs
@@ -36,7 +36,7 @@ pub struct GithubReleaseAsset {
     pub id: i64,
     pub node_id: String,
     pub name: String,
-    pub label: String,
+    pub label: Option<String>,
     pub content_type: String,
     pub state: String,
     pub size: i64,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,7 +48,7 @@ pub enum OrandaError {
     #[error("Failed parsing response when fetching releases from Github.")]
     GithubReleaseParseError {
         #[source]
-        details: reqwest::Error,
+        details: axoasset::AxoassetError,
     },
 
     #[error("Could not find any releases from {repo_owner}/{repo_name} with a cargo-dist compatible `dist-manifest.json`.")]


### PR DESCRIPTION
fixes #347 

old error:
<img width="725" alt="Screenshot 2023-05-26 at 12 09 03 PM" src="https://github.com/axodotdev/oranda/assets/1163554/105fe4b3-30a8-4e27-aefd-a499c1b8a48e">

new error:
![image](https://github.com/axodotdev/oranda/assets/1163554/d77c5578-e68b-452c-8f9f-2d4f7c1641ef)
