### PR TITLE
Write "pretty links" to destination directory

### DIFF
--- a/src/site/artifacts/installers.rs
+++ b/src/site/artifacts/installers.rs
@@ -15,7 +15,7 @@ struct InstallerData {
 }
 
 pub fn build_header(latest_release: &DistRelease, config: &Config) -> Result<Box<div<String>>> {
-    let downloads_href = link::generate(&config.path_prefix, "artifacts.html");
+    let downloads_href = link::generate(&config.path_prefix, "artifacts/");
 
     let mut html: Vec<Box<div<String>>> = vec![];
     let manifest = &latest_release.manifest;

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -19,7 +19,7 @@ pub fn build(context: &Context, config: &Config) -> Result<String> {
             ""
         };
 
-        let link = format!("changelog/{}.html", &release.source.tag_name);
+        let link = format!("{}/", &release.source.tag_name);
 
         releases_html.extend(build_page_preview(release, config, true)?);
         releases_nav.extend(
@@ -100,7 +100,7 @@ pub fn build_page_preview(
         "release"
     };
     let link = if is_page {
-        format!("changelog/{}.html", &tag_name)
+        format!("{}/", &tag_name)
     } else {
         format!("#{}", &tag_name)
     };

--- a/src/site/layout/header.rs
+++ b/src/site/layout/header.rs
@@ -37,7 +37,7 @@ fn nav(
 ) -> Result<Box<nav<String>>> {
     Message::new(MessageType::Info, "Building nav...").print();
     let mut html: Vec<Box<li<String>>> = if let Some(prefix) = &path_prefix {
-        let href = format!("/{}", prefix);
+        let href = format!("/{}/", prefix);
         vec![html!(<li><a href=href>"Home"</a></li>)]
     } else {
         vec![html!(<li><a href="/">"Home"</a></li>)]
@@ -50,10 +50,8 @@ fn nav(
                 let file_path = page::source::get_filename(page_path);
 
                 if let Some(file_name) = file_path {
-                    let href = link::generate(
-                        path_prefix,
-                        &format!("{}.html", file_name.to_string_lossy()),
-                    );
+                    let href =
+                        link::generate(path_prefix, &format!("{}/", file_name.to_string_lossy()));
 
                     html.extend(html!(<li><a href=href>{text!(page_name)}</a></li>));
                 } else {
@@ -69,7 +67,7 @@ fn nav(
 
     if artifacts.has_some() {
         Message::new(MessageType::Info, "Adding artifacts page...").print();
-        let href = link::generate(path_prefix, "artifacts.html");
+        let href = link::generate(path_prefix, "artifacts/");
         html.extend(html!(<li><a href=href>{text!("Install")}</a></li>));
     };
 
@@ -86,9 +84,9 @@ fn nav(
     if *changelog {
         Message::new(MessageType::Info, "Adding changelog...").print();
         let href = if let Some(prefix) = &path_prefix {
-            format!("/{}/{}", prefix, "changelog.html")
+            format!("/{}/{}/", prefix, "changelog")
         } else {
-            format!("/{}", "changelog.html")
+            format!("/{}/", "changelog")
         };
         html.extend(html!(<li><a href=href>{text!("Changelog")}</a></li>));
     };

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -21,7 +21,7 @@ fn it_adds_additional_css() {
     let page = page::index(&config, &layout);
     assert!(page
         .contents
-        .contains("<link href=\"/custom.css\" rel=\"stylesheet\"/>"));
+        .contains(r#"<link href="/custom.css" rel="stylesheet"/>"#));
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn it_renders_changelog_with_no_cargo_dist() {
     let config = oranda_config::changelog(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::changelog(&config, &layout);
-    assert!(page.contents.contains("<h1>Releases</h1>"));
+    assert!(page.contents.contains(r#"<h1>Releases</h1>"#));
 }
 
 #[test]
@@ -64,7 +64,7 @@ fn it_adds_oranda_css_with_pinned_version() {
     let page = page::index(&config, &layout);
     assert!(page
         .contents
-        .contains("<link href=\"/oranda-v0.0.3.css\" rel=\"stylesheet\"/>"));
+        .contains(r#"<link href="/oranda-v0.0.3.css" rel="stylesheet"/>"#));
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn it_builds_the_site() {
     let config = oranda_config::no_artifacts(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index(&config, &layout);
-    assert!(page.contents.contains("<h1>axo</h1>"));
+    assert!(page.contents.contains(r#"<h1>axo</h1>"#));
     assert!(page.contents.contains("custom.css"));
 }
 
@@ -96,7 +96,7 @@ fn reads_theme() {
     let config = oranda_config::no_artifacts(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index(&config, &layout);
-    assert!(page.contents.contains("html class=\"dark\""));
+    assert!(page.contents.contains(r#"html class="dark""#));
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn creates_nav() {
     let config = oranda_config::no_artifacts(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index(&config, &layout);
-    assert!(page.contents.contains("<nav class=\"nav\"><ul><li><a href=\"/\">Home</a></li><li><a href=\"/README.html\">Another Page</a></li></ul></nav>"));
+    assert!(page.contents.contains(r#"<nav class="nav"><ul><li><a href="/">Home</a></li><li><a href="/README/">Another Page</a></li></ul></nav>"#));
 }
 
 #[test]
@@ -116,7 +116,7 @@ fn creates_nav_no_additional_pages() {
     let config = oranda_config::no_artifacts(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index(&config, &layout);
-    assert!(page.contents.contains("<nav class=\"nav\">"));
+    assert!(page.contents.contains(r#"<nav class="nav">"#));
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn creates_footer() {
     let page = page::index(&config, &layout);
     assert!(page
         .contents
-        .contains("<footer class=\"footer\"><span>My Axo project</span></footer>"));
+        .contains(r#"<footer class="footer"><span>My Axo project</span></footer>"#));
 }
 
 #[test]
@@ -140,7 +140,7 @@ fn creates_nav_item() {
     let page = page::index_with_artifacts(&config, &layout);
     assert!(page
         .contents
-        .contains("<li><a href=\"/artifacts.html\">Install</a></li>"));
+        .contains(r#"<li><a href="/artifacts/">Install</a></li>"#));
 }
 
 #[test]
@@ -150,7 +150,7 @@ fn loads_js() {
     let config = oranda_config::cargo_dist(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index_with_artifacts(&config, &layout);
-    assert!(page.contents.contains("<script src=\"/artifacts.js\">"));
+    assert!(page.contents.contains(r#"<script src="/artifacts.js">"#));
 }
 
 #[test]
@@ -160,7 +160,7 @@ fn creates_download_for_mac() {
     let config = oranda_config::cargo_dist(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index_with_artifacts(&config, &layout);
-    assert!(page.contents.contains("<span class=\"detect\">We have detected you are on <span class=\"detected-os\">mac</span>, are we wrong?</span>"));
+    assert!(page.contents.contains(r#"<span class="detect">We have detected you are on <span class="detected-os">mac</span>, are we wrong?</span>"#));
 }
 
 #[test]
@@ -170,13 +170,13 @@ fn creates_downloads_page() {
     let config = oranda_config::cargo_dist(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let artifacts_page = page::artifacts(&config, &layout);
-    assert!(artifacts_page.contents.contains("<h3>Downloads</h3>"));
+    assert!(artifacts_page.contents.contains(r#"<h3>Downloads</h3>"#));
     assert!(artifacts_page
         .contents
-        .contains("<span>Executable Zip</span><span>x86_64-pc-windows-msvc</span>"));
+        .contains(r#"<span>Executable Zip</span><span>x86_64-pc-windows-msvc</span>"#));
     assert!(artifacts_page
         .contents
-        .contains("<h3>Install via script</h3>"))
+        .contains(r#"<h3>Install via script</h3>"#))
 }
 
 #[test]
@@ -197,7 +197,7 @@ fn creates_copy_to_clipboard_home() {
     let layout = Layout::new(&config).unwrap();
     let page = page::index_with_artifacts(&config, &layout);
     assert!(page.contents.contains("copy-clipboard-button"));
-    assert!(page.contents.contains("installer.sh.txt\">Source</a>"));
+    assert!(page.contents.contains(r#"installer.sh.txt">Source</a>"#));
 }
 
 #[test]
@@ -209,7 +209,7 @@ fn creates_copy_to_clipboard_artifacts() {
     let page = page::artifacts(&config, &layout);
     assert!(page
         .contents
-        .contains("<button class=\"button primary\" data-copy=\"npm install oranda\">"));
+        .contains(r#"<button class="button primary" data-copy="npm install oranda">"#));
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn adds_prefix() {
     assert!(page.contents.contains("<script src=\"/axo/artifacts.js\">"));
     assert!(page
         .contents
-        .contains("<a href=\"/axo/artifacts.html\">View all installation options</a>"))
+        .contains(r#"<a href="/axo/artifacts/">View all installation options</a>"#))
 }
 
 #[test]
@@ -232,7 +232,8 @@ fn adds_changelog_nav() {
     let config = oranda_config::changelog(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index(&config, &layout);
-    assert!(page.contents.contains("changelog.html"));
+    dbg!(&page.contents);
+    assert!(page.contents.contains("/changelog/"));
 }
 
 #[test]

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -232,7 +232,6 @@ fn adds_changelog_nav() {
     let config = oranda_config::changelog(temp_dir);
     let layout = Layout::new(&config).unwrap();
     let page = page::index(&config, &layout);
-    dbg!(&page.contents);
     assert!(page.contents.contains("/changelog/"));
 }
 


### PR DESCRIPTION
Instead of writing `changelog.html` (for example), we want to write `changelog.html` so that the end user can generate "pretty links", i.e. linking to `https://mysite.com/changelog`. This PR Does That.

I ended up being extra pedantic about creating links wit h a trailing slash, because some links didn't, and therefore broke when the user supplied a custom path prefix (when you link to `/mypathprefix/changelog`, the browser can interpret it as linking to `/changelog` for some reason?).

I also updated build tests to use raw string literals for any HTML strings we were testing for, since that saves us a bunch of having to escape quotation marks.