### PR TITLE
feat(auto-mdbook): add autodetection for mdbook

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -1,10 +1,6 @@
 {
   "favicon": "https://www.axo.dev/favicon.ico",
   "path_prefix": "oranda",
-  "mdbook": {
-    "path": "./docs",
-    "theme": true
-  },
   "changelog": true,
   "social": {
     "image": "https://www.axo.dev/meta_small.jpeg",

--- a/src/config/oranda_config.rs
+++ b/src/config/oranda_config.rs
@@ -20,10 +20,12 @@ pub struct Social {
 }
 
 /// Config for us building and integrating your mdbook
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct MdBookConfig {
     /// Path to the mdbook
-    pub path: String,
+    ///
+    /// If not set we will attempt to auto-detect
+    pub path: Option<String>,
     /// Whether to enable the custom oranda/axo theme
     pub theme: Option<bool>,
 }
@@ -68,8 +70,12 @@ pub struct OrandaConfig {
     pub path_prefix: Option<String>,
     pub license: Option<String>,
     /// Config for mdbook
+    ///
+    /// We allow this to be set to just `false` to give the user
+    /// an easy way to force-disable any errant autodetection.
+    /// Setting it to `true` is allowed but equivalent to `None`.
     #[serde(alias = "md_book")]
-    pub mdbook: Option<MdBookConfig>,
+    pub mdbook: Option<BoolOr<MdBookConfig>>,
     pub changelog: Option<bool>,
     pub styles: Option<StyleConfig>,
 }
@@ -93,4 +99,17 @@ impl OrandaConfig {
             }
         }
     }
+}
+
+/// A value or just a boolean
+///
+/// This allows us to have a simple yes/no version of a config while still
+/// allowing for a more advanced version to exist.
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum BoolOr<T> {
+    /// They gave the simple bool
+    Bool(bool),
+    /// They gave a more interesting value
+    Val(T),
 }

--- a/src/site/mdbook.rs
+++ b/src/site/mdbook.rs
@@ -89,7 +89,11 @@ impl AxomdbookTheme {
 /// should do this mapping for us, when it still knows where oranda.json is!
 pub fn mdbook_dir(book_cfg: &MdBookConfig) -> Result<Utf8PathBuf> {
     let pwd = axoasset::LocalAsset::current_dir()?;
-    Ok(pwd.join(&book_cfg.path))
+    let book_path = book_cfg
+        .path
+        .as_ref()
+        .expect("Had no mdbook.path, but config code didn't disable mdbook?");
+    Ok(pwd.join(book_path))
 }
 
 /// Gets the custom theme to set in an mdbook

--- a/tests/build/fixtures/oranda_config.rs
+++ b/tests/build/fixtures/oranda_config.rs
@@ -25,6 +25,7 @@ pub fn no_artifacts(temp_dir: String) -> Config {
             )],
             ..Default::default()
         },
+        mdbook: None,
         ..Default::default()
     }
 }


### PR DESCRIPTION
All of the following are now valid values for the mdbook config:

* (no key) - enables mdbook, autodetects path, custom theme
* mdbook: true - redundant synonym for the above
* mdbook: false - disables mdbook
* mdbook: { path: ./doc/ } - enables mdbook with an explicit path, custom theme
* mdbook: { theme: false } - enables mdbook, autodetects path, disables custom theme