### PR TITLE
rewrite dev watch logic to use debouncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,6 +1948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-debouncer-mini"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55ee272914f4563a2f8b8553eb6811f3c0caea81c756346bad15b7e3ef969f0"
+dependencies = [
+ "crossbeam-channel",
+ "notify",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,7 +2136,7 @@ dependencies = [
  "mdbook",
  "miette",
  "minifier",
- "notify",
+ "notify-debouncer-mini",
  "octolotl",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ camino = "1.1.4"
 miette = "5.7.0"
 futures-util = "0.3.28"
 mdbook = { version = "0.4.17", default-features = false, features = ["search"] }
-notify = "6.0.0"
+notify-debouncer-mini = "0.3.0"
 toml_edit = "0.19.9"
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -131,7 +131,7 @@ pub enum OrandaError {
 
     #[error("We were unable to watch your filesystem for changes")]
     #[diagnostic(help = "Make sure that oranda has privileges to set up file watchers!")]
-    FilesystemWatchError(#[from] notify::Error),
+    FilesystemWatchError(#[from] notify_debouncer_mini::notify::Error),
 
     #[error("{0}")]
     Other(String),


### PR DESCRIPTION
Fixes multiple fs events firing right after each other by relying on a debouncing notify watcher. Also includes a fix that'll only tell the user that we're watching the paths that actually exist.