### PR TITLE
add nix flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ oranda-debug.log
 # oranda-css
 oranda-css/dist
 node_modules
+
+# nix
+result/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oranda"
 description = "🎁 generate beautiful landing pages for your projects"
 repository = "https://github.com/axodotdev/oranda"
+homepage = "https://opensource.axo.dev/oranda"
 version = "0.1.0-prerelease.5"
 edition = "2021"
 authors = ["Axo Developer Co. <hello@axo.dev>"]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1686032467,
+        "narHash": "sha256-KUCS237H0G1QGx5ehhEmh5yKtcDGCxvVXVtz8xEDAKE=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "1a3e0f661119a7435099b118912d65bdbbf3bb11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685931219,
+        "narHash": "sha256-8EWeOZ6LKQfgAjB/USffUSELPRjw88A+xTcXnOUvO5M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7409480d5c8584a1a83c422530419efe4afb0d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685984106,
+        "narHash": "sha256-dOEuU1AuASOWdXT/SbVpD8uX7JjiW3lCp08SbviHuww=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "d42d55feaafa71e14521bbfe6e7011fbb41980f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,111 @@
+{
+  description = "🎁 generate beautiful landing pages for your developer tools";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , fenix
+    , ...
+    }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            fenix.overlays.default
+          ];
+        };
+
+        # Parse the local Cargo.toml so we track the usual rust workflow
+        cargo_toml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+        package = with pkgs;
+          rustPlatform.buildRustPackage {
+            pname = cargo_toml.package.name;
+            version = cargo_toml.package.version;
+            src = ./.;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            # Don't run checks
+            doCheck = false;
+
+            # Package metadata
+            meta = with pkgs.lib; {
+              description = cargo_toml.package.description;
+              homepage = cargo_toml.package.repository;
+              license = with licenses; [ asl20 mit ];
+            };
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+            ];
+
+            buildInputs = with pkgs; ([
+              bzip2
+              oniguruma
+              openssl
+              xz
+              zstd
+            ]
+            ++ darwinInputs);
+
+            RUSTONIG_SYSTEM_LIBONIG = true;
+            ZSTD_SYS_USE_PKG_CONFIG = true;
+            NIX_LDFLAGS = nixLdFlags;
+          };
+
+        # Darwin-specific build requirements
+        frameworks = pkgs.darwin.apple_sdk.frameworks;
+        darwinInputs = with pkgs; (lib.optionals stdenv.isDarwin [ libiconv frameworks.Security ]);
+        nixLdFlags = with pkgs; (lib.optionalString (stdenv.isDarwin) "-F${frameworks.CoreServices}/Library/Frameworks -framework CoreServices -L${libiconv}/lib");
+      in
+      {
+        packages = rec {
+          oranda = package;
+          default = oranda;
+        };
+
+        devShells = with pkgs; {
+          default = mkShell {
+            nativeBuildInputs = [
+              pkg-config
+            ];
+
+            buildInputs =
+              [
+                (fenix.packages.${system}.complete.withComponents [
+                  "cargo"
+                  "clippy"
+                  "rust-src"
+                  "rustc"
+                  "rustfmt"
+                ])
+              ]
+              ++ darwinInputs;
+
+            # Allow rust-analyzer and other tools to see rust src
+            RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
+
+            # Fix missing OpenSSL
+            PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+
+            shellHook = ''
+              export NIX_LDFLAGS="${nixLdFlags}"
+            '';
+          };
+        };
+      });
+}


### PR DESCRIPTION
This PR adds:
- a `homepage` definition to `[package]` in `Cargo.toml`,
- a `flake.nix` which allows building oranda with `nix build` and dropping into a dev shell with `nix develop`,
- a line to `.gitignore` preventing accidental commits of the `nix build` result directory.

Note: I have only tested this on aarch64-darwin and x86_64-linux.