### PR TITLE
add repository key to config

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -23,5 +23,6 @@
     "plausible": {
       "domain": "opensource.axo.dev"
     }
-  }
+  },
+  "repository": "https://github.com/axodotdev/oranda"
 }


### PR DESCRIPTION
This tiny patch fixes an [error](https://github.com/axodotdev/oranda/blob/main/src/site/mod.rs#L67) thrown when running `oranda build` in this repo:

> × You have indicated you want to use features that require a repository
> │ context. Please add a "repository" key and value to your project (such as
> │ a package.json or Cargo.toml) or oranda config (oranda.json).
