### PR TITLE
add nix install instructions to docs and config

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -36,7 +36,7 @@ npm install oranda
 ```
 
 ## Install With Nix
-oranda is available in [`nixpkgs`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/oranda/default.nix), and also as a nix flake.
+oranda is available in [`nixpkgs`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/oranda/default.nix), and also as a nix flake. This installer is currently experimental, so we don't recommend you use it in production workflows.
 
 On a system with nix installed, you can run
 ```sh

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -35,5 +35,18 @@ cargo install oranda --locked --profile=dist
 npm install oranda
 ```
 
+## Install With Nix
+oranda is available in [`nixpkgs`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/oranda/default.nix), and also as a nix flake.
+
+On a system with nix installed, you can run
+```sh
+nix-env -i oranda
+```
+
+or to install from GitHub using the flake,
+```sh
+nix profile install github:axodotdev/oranda
+```
+
 [cargo-binstall]:https://github.com/cargo-bins/cargo-binstall
 [website]: https://opensource.axo.dev/oranda

--- a/oranda.json
+++ b/oranda.json
@@ -16,7 +16,9 @@
       "npm": "npm install @axodotdev/oranda --save-dev",
       "npx": "npx @axodotdev/oranda",
       "crates.io": "cargo install oranda --locked --profile=dist",
-      "binstall": "cargo binstall oranda"
+      "binstall": "cargo binstall oranda",
+      "nix-env": "nix-env -i oranda",
+      "nix flake": "nix profile install github:axodotdev/oranda"
     }
   },
   "analytics": {


### PR DESCRIPTION
(This PR replaces https://github.com/axodotdev/oranda/pull/366, doing the same thing but with correct git history this time. Apologies for the mess.)

Following the addition of `flake.nix` with https://github.com/axodotdev/oranda/pull/365 (and the earlier addition of oranda to nixpkgs https://github.com/NixOS/nixpkgs/pull/230974), this PR adds Nix-based installation instructions to
- the `oranda.json` config file
<img width="810" alt="Screenshot 2023-06-08 at 11 05 54" src="https://github.com/axodotdev/oranda/assets/74747193/e559d0d4-4517-4afc-b836-13e0abfe463d">

- and `docs/src/install.md`
<img width="792" alt="Screenshot 2023-06-08 at 11 06 13" src="https://github.com/axodotdev/oranda/assets/74747193/57bd8aef-28a3-4178-92ef-86f5261d185e">