### PR TITLE
Ensure package managers link respects path prefix

### DIFF
--- a/src/site/artifacts/package_managers.rs
+++ b/src/site/artifacts/package_managers.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::errors::*;
-use crate::site::icons;
 use crate::site::markdown::{syntax_highlight, SyntaxTheme};
+use crate::site::{icons, link};
 use indexmap::IndexMap;
 
 use axohtml::elements::div;
@@ -57,12 +57,13 @@ pub fn build_header(
         )));
     };
     let install_code = create_package_install_code(hint.as_str(), &config.styles.syntax_theme());
+    let downloads_href = link::generate(&config.path_prefix, "artifacts.html");
 
     Ok(html!(<div>
     <h4 class="text-center">{text!(format!("Install with {}", manager))}</h4>
     {unsafe_text!(install_code)}
     <div>
-        <a href="/artifacts.html" class="download-all">{text!("View all downloads")}</a>
+        <a href=downloads_href class="download-all">{text!("View all downloads")}</a>
     </div>
 </div>))
 }

--- a/tests/build/fixtures/oranda_config.rs
+++ b/tests/build/fixtures/oranda_config.rs
@@ -75,6 +75,29 @@ pub fn path_prefix(temp_dir: String) -> Config {
     }
 }
 
+pub fn path_prefix_with_package_managers(temp_dir: String) -> Config {
+    let mut package_managers = IndexMap::new();
+    package_managers.insert(String::from("npm"), String::from("npm install oranda"));
+    package_managers.insert(String::from("yarn"), String::from("yarn add oranda"));
+    Config {
+        dist_dir: temp_dir,
+        path_prefix: Some(String::from("axo")),
+        artifacts: Artifacts {
+            cargo_dist: Some(false),
+            package_managers: Some(package_managers),
+        },
+        styles: StyleConfig {
+            additional_css: vec![String::from(
+                "https://raw.githubusercontent.com/axodotdev/axii/main/css/main.css",
+            )],
+            ..Default::default()
+        },
+        repository: Some(String::from("https://github.com/axodotdev/oranda")),
+        version: Some(String::from("0.0.1-prerelease2")),
+        ..Default::default()
+    }
+}
+
 pub fn cargo_dist(temp_dir: String) -> Config {
     Config {
         dist_dir: temp_dir,

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -226,6 +226,19 @@ fn adds_prefix() {
 }
 
 #[test]
+fn adds_prefix_with_package_managers() {
+    let _guard = TEST_RUNTIME.enter();
+    let (_t, temp_dir) = temp_build_dir();
+    let config = oranda_config::path_prefix_with_package_managers(temp_dir);
+    let layout = Layout::new(&config).unwrap();
+    let page = page::index_with_artifacts(&config, &layout);
+    assert!(page.contents.contains("<script src=\"/axo/artifacts.js\">"));
+    assert!(page
+        .contents
+        .contains(r#"<a class="download-all" href="/axo/artifacts.html">View all downloads</a>"#));
+}
+
+#[test]
 fn adds_changelog_nav() {
     let _guard = TEST_RUNTIME.enter();
     let (_t, temp_dir) = temp_build_dir();


### PR DESCRIPTION
Fixes an issue I discovered on my generated page (https://msfjarvis.github.io/twt/) where the 'View all downloads' URL did not have a path prefix and thus causes a 404.
