### PR TITLE
chore: update ci to latest oranda

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -62,7 +62,7 @@ jobs:
       # This will write all output to ./public/ (including copying mdbook's output to there)
       - name: Install and run oranda
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.1.0-prerelease.6/oranda-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.1.0-prerelease.7/oranda-installer.sh | sh
           oranda build
 
       # Deploy to our gh-pages branch (making it if it doesn't exist)

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -62,7 +62,7 @@ jobs:
       # This will write all output to ./public/ (including copying mdbook's output to there)
       - name: Install and run oranda
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.1.0-prerelease.7/oranda-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.1.0-prerelease.8/oranda-installer.sh | sh
           oranda build
 
       # Deploy to our gh-pages branch (making it if it doesn't exist)

--- a/oranda.json
+++ b/oranda.json
@@ -10,13 +10,12 @@
   "artifacts": {
     "package_managers": {
       "preferred": {
-        "crates.io": "cargo install oranda --locked --profile=dist",
-        "npm": "npm install @axodotdev/oranda --save-dev",
-        "binstall": "cargo binstall oranda"
+        "cargo": "cargo install oranda --locked --profile=dist",
+        "npm": "npm install @axodotdev/oranda --save-dev"
       },
       "additional": {
+        "binstall": "cargo binstall oranda",
         "npx": "npx @axodotdev/oranda",
-        "crates.io": "cargo install oranda --locked --profile=dist",
         "nix-env": "nix-env -i oranda",
         "nix flake": "nix profile install github:axodotdev/oranda"
       }

--- a/oranda.json
+++ b/oranda.json
@@ -9,13 +9,21 @@
   },
   "artifacts": {
     "package_managers": {
-      "npm": "npm install @axodotdev/oranda --save-dev",
-      "npx": "npx @axodotdev/oranda",
-      "crates.io": "cargo install oranda --locked --profile=dist",
-      "binstall": "cargo binstall oranda",
-      "nix-env": "nix-env -i oranda",
-      "nix flake": "nix profile install github:axodotdev/oranda"
+      "preferred": {
+        "crates.io": "cargo install oranda --locked --profile=dist",
+        "npm": "npm install @axodotdev/oranda --save-dev",
+        "binstall": "cargo binstall oranda"
+      },
+      "additional": {
+        "npx": "npx @axodotdev/oranda",
+        "crates.io": "cargo install oranda --locked --profile=dist",
+        "nix-env": "nix-env -i oranda",
+        "nix flake": "nix profile install github:axodotdev/oranda"
+      }
     }
+  },
+  "styles": {
+    "theme": "axodark"
   },
   "analytics": {
     "plausible": {

--- a/oranda.json
+++ b/oranda.json
@@ -1,32 +1,38 @@
 {
-  "favicon": "https://www.axo.dev/favicon.ico",
-  "path_prefix": "oranda",
-  "changelog": true,
-  "social": {
-    "image": "https://www.axo.dev/meta_small.jpeg",
-    "image_alt": "axo",
-    "twitter_account": "@axodotdev"
+  "build": {
+    "path_prefix": "oranda"
   },
-  "artifacts": {
-    "package_managers": {
-      "preferred": {
-        "cargo": "cargo install oranda --locked --profile=dist",
-        "npm": "npm install @axodotdev/oranda --save-dev"
-      },
-      "additional": {
-        "binstall": "cargo binstall oranda",
-        "npx": "npx @axodotdev/oranda",
-        "nix-env": "nix-env -i oranda",
-        "nix flake": "nix profile install github:axodotdev/oranda"
+  "styles": {
+    "theme": "axodark",
+    "favicon": "https://www.axo.dev/favicon.ico"
+  },
+  "marketing": {
+    "social": {
+      "image": "https://www.axo.dev/meta_small.jpeg",
+      "image_alt": "axo",
+      "twitter_account": "@axodotdev"
+    },
+    "analytics": {
+      "plausible": {
+        "domain": "opensource.axo.dev"
       }
     }
   },
-  "styles": {
-    "theme": "axodark"
-  },
-  "analytics": {
-    "plausible": {
-      "domain": "opensource.axo.dev"
+  "components": {
+    "changelog": true,
+    "artifacts": {
+      "package_managers": {
+        "preferred": {
+          "npm": "npm install @axodotdev/oranda --save-dev",
+          "cargo": "cargo install oranda --locked --profile=dist"
+        },
+        "additional": {
+          "npx": "npx @axodotdev/oranda",
+          "binstall": "cargo binstall oranda",
+          "nix-env": "nix-env -i oranda",
+          "nix flake": "nix profile install github:axodotdev/oranda"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR will handle updating the CI and oranda.json in lockstep. It should only be landed once:

* [x] cut a new release (separate PR)
* [x] fix style of readme nubs (separate PR)
* [x] update version in ci (this PR)
* [x] decide which package managers should be preferred vs additional (this PR)

