### PR TITLE
fix: properly escape paths when generating urls

### DIFF
--- a/src/site/layout/header.rs
+++ b/src/site/layout/header.rs
@@ -9,12 +9,18 @@ use axohtml::{html, text};
 use indexmap::IndexMap;
 
 fn get_logo(logo: String, config: &Config) -> Result<Box<img<String>>> {
-    let fetched_logo = fetch_logo(&config.build.dist_dir, logo, &config.project.name);
+    let fetched_logo = fetch_logo(
+        &config.build.path_prefix,
+        &config.build.dist_dir,
+        logo,
+        &config.project.name,
+    );
 
     tokio::runtime::Handle::current().block_on(fetched_logo)
 }
 
 async fn fetch_logo(
+    path_prefix: &Option<String>,
     dist_dir: &str,
     origin_path: String,
     name: &String,
@@ -22,8 +28,9 @@ async fn fetch_logo(
     let copy_result = Asset::copy(&origin_path, dist_dir).await?;
 
     let path_as_string = copy_result.strip_prefix(dist_dir)?.to_string_lossy();
+    let src = link::generate(path_prefix, &path_as_string);
 
-    Ok(html!(<img src=path_as_string alt=name class="logo" />))
+    Ok(html!(<img src=src alt=name class="logo" />))
 }
 
 fn nav(

--- a/src/site/link.rs
+++ b/src/site/link.rs
@@ -20,5 +20,11 @@ pub fn generate(path_prefix: &Option<String>, file_name: &str) -> String {
             part.as_str().as_bytes(),
         ));
     }
+
+    // re-add a trailing slash if original input had it
+    if file_name.ends_with('/') {
+        output.push('/');
+    }
+
     output
 }

--- a/src/site/link.rs
+++ b/src/site/link.rs
@@ -1,7 +1,24 @@
+use camino::Utf8PathBuf;
+
 pub fn generate(path_prefix: &Option<String>, file_name: &str) -> String {
-    if let Some(prefix) = &path_prefix {
-        format!("/{}/{}", prefix, file_name)
+    // NOTE: intentionally no leading `/` here because it makes camino add a phantom `/` or `\`
+    // to the front of the path when getting its components (because it's trying to tell us
+    // the path is absolute, and we already know that).
+    let url = if let Some(prefix) = &path_prefix {
+        format!("{}/{}", prefix, file_name)
     } else {
-        format!("/{}", file_name)
+        file_name.to_owned()
+    };
+
+    // Break the url up into its segments, and precent-encode each part,
+    // prepending a `/` before each part to make the resulting URL absolute
+    let path = Utf8PathBuf::from(url);
+    let mut output = String::new();
+    for part in path.components() {
+        output.push('/');
+        output.extend(url::form_urlencoded::byte_serialize(
+            part.as_str().as_bytes(),
+        ));
     }
+    output
 }


### PR DESCRIPTION
also make logo linking properly use link::generate