### PR TITLE
fix: make installers/artifacts possible with no repo

### DIFF
--- a/src/site/artifacts/table.rs
+++ b/src/site/artifacts/table.rs
@@ -36,7 +36,7 @@ pub fn build(release: &Release, _config: &Config) -> Result<Box<div<String>>> {
     files.sort_by_key(|(_, (f, _))| &f.name);
 
     if files.is_empty() {
-        return Ok(html!(<div>{text!("No Additional Downloads")}</div>));
+        return Ok(html!(<div><h3>{text!("No Downloads")}</h3></div>));
     }
 
     // If any files have checksums, add a column for that

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -46,7 +46,7 @@ pub fn index(config: &Config, layout: &Layout) -> Page {
 pub fn index_with_artifacts(config: &Config, layout: &Layout) -> Page {
     reset(&config.build.dist_dir);
     let repo_url = config.project.repository.as_ref().unwrap();
-    let mut context = Context::new(repo_url, &config.components.artifacts).unwrap();
+    let mut context = Context::new_github(repo_url, config).unwrap();
     if let Some(latest) = context.latest_mut() {
         latest.artifacts.make_scripts_viewable(config).unwrap();
     }
@@ -62,7 +62,7 @@ pub fn index_with_warning(config: &Config, layout: &Layout) -> Page {
 pub fn artifacts(config: &Config, layout: &Layout) -> Page {
     reset(&config.build.dist_dir);
     let repo_url = config.project.repository.as_ref().unwrap();
-    let context = Context::new(repo_url, &config.components.artifacts).unwrap();
+    let context = Context::new_github(repo_url, config).unwrap();
     let artifacts_content = artifacts::page(&context, config).unwrap();
     Page::new_from_contents(artifacts_content, "artifacts.html", layout, config)
 }
@@ -70,7 +70,7 @@ pub fn artifacts(config: &Config, layout: &Layout) -> Page {
 pub fn changelog(config: &Config, layout: &Layout) -> Page {
     reset(&config.build.dist_dir);
     let repo_url = config.project.repository.as_ref().unwrap();
-    let context = Context::new(repo_url, &config.components.artifacts).unwrap();
+    let context = Context::new_github(repo_url, config).unwrap();
     let changelog_content = changelog::build(&context, config).unwrap();
     Page::new_from_contents(changelog_content, "changelog.html", layout, config)
 }


### PR DESCRIPTION
This adds a new ReleaseSource enum and a Current variant that is just based on values found in the current project, used to fallback when Github is empty or there's no repo.