### PR TITLE
fix: hide and document the testing flags

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -8,8 +8,18 @@ use oranda::site::Site;
 
 #[derive(Debug, Parser)]
 pub struct Build {
+    /// DO NOT USE: Path to the root dir of the project
+    ///
+    /// This flag exists for internal testing. It is incorrectly implemented for actual
+    /// end-users and will make you very confused and sad.
+    #[clap(hide = true)]
     #[arg(long, default_value = "./")]
     project_root: Utf8PathBuf,
+    /// DO NOT USE: Path to the oranda.json
+    ///
+    /// This flag exists for internal testing. It is incorrectly implemented for actual
+    /// end-users and will make you very confused and sad.
+    #[clap(hide = true)]
     #[arg(long, default_value = "./oranda.json")]
     config_path: Utf8PathBuf,
 }

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -21,10 +21,18 @@ pub struct Dev {
     /// The port for the file server to be launched on
     #[arg(long)]
     port: Option<u16>,
-    /// The project root we want to build from
+    /// DO NOT USE: Path to the root dir of the project
+    ///
+    /// This flag exists for internal testing. It is incorrectly implemented for actual
+    /// end-users and will make you very confused and sad.
+    #[clap(hide = true)]
     #[arg(long)]
     project_root: Option<Utf8PathBuf>,
-    /// Custom path to an oranda configuration file
+    /// DO NOT USE: Path to the oranda.json
+    ///
+    /// This flag exists for internal testing. It is incorrectly implemented for actual
+    /// end-users and will make you very confused and sad.
+    #[clap(hide = true)]
     #[arg(long)]
     config_path: Option<Utf8PathBuf>,
     /// Skip the first build before starting to watch for changes


### PR DESCRIPTION
fixes #95

These flags only exist for our test-suite, and won't behave correctly because we don't yet make paths relative to the file we read them from