### PR TITLE
fix(artifacts): fix copypasta fail for run hint inference

### DIFF
--- a/src/data/artifacts/inference.rs
+++ b/src/data/artifacts/inference.rs
@@ -276,12 +276,12 @@ fn infer_targets_for_script(file: &File) -> Vec<TargetTriple> {
 
 /// Infer the command to curl|sh a script
 fn infer_run_hint_for_script(file: &File) -> String {
-    if file.name.ends_with(EXT_SCRIPT_POWERSHELL) {
+    if file.name.ends_with(EXT_SCRIPT_SHELL) {
         format!(
             "curl --proto '=https' --tlsv1.2 -LsSf {} | sh",
             file.download_url
         )
-    } else if file.name.ends_with(EXT_SCRIPT_SHELL) {
+    } else if file.name.ends_with(EXT_SCRIPT_POWERSHELL) {
         format!("irm {} | iex", file.download_url)
     } else {
         unimplemented!(


### PR DESCRIPTION
The checks for PowerShell and `sh` were swapped around which resulted in generated sites recommending `irm` for shell scripts and `curl` for PowerShell ones :D

No tests failed post this change so I guess there is no coverage, I can add a test if someone can point to where it should go.
