### PR TITLE
chore: remove pull request trigger for gallery

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -1,7 +1,6 @@
 name: Project Gallery
 
 on:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
Actions doesn't pass secrets to PR workflows, so this'll not work in its current state, and I'd rather have green checks.