### PR TITLE
fix: don't default highlight untagged code blocks

### DIFF
--- a/src/site/markdown/syntax_highlight/mod.rs
+++ b/src/site/markdown/syntax_highlight/mod.rs
@@ -64,7 +64,7 @@ pub fn syntax_highlight(
         .collect::<Result<BTreeMap<String, Theme>>>()?;
     let theme_set = ThemeSet { themes };
     let language = match lang {
-        None | Some("") => "rs",
+        None => "",
         Some("text") => "txt",
         Some("shell") => "sh",
         Some(l) => l,


### PR DESCRIPTION
Simplest possible solution to close #310.
The proper way to write code blocks in Markdown is to tag them with the language, and we should not be trying to infer anything or be smart about it (for now, although I'm personally for the ideological approach on this)