### PR TITLE
Hide installer widget on mobile

### DIFF
--- a/oranda-css/css/pages/artifacts.css
+++ b/oranda-css/css/pages/artifacts.css
@@ -11,7 +11,7 @@
 }
 
 .artifacts {
-  @apply flex items-center flex-col mb-8 p-0;
+  @apply sm:flex items-center flex-col mb-8 p-0 hidden;
   color: var(--light-highlight-fg-color);
   background-color: var(--light-highlight-bg-color);
 }
@@ -28,7 +28,6 @@ ul.tabs {
 ul.tabs li {
   @apply hover:cursor-pointer m-0 px-3 py-2 text-base;
 }
-
 
 ul.tabs li.selected {
   color: var(--light-highlight-bg-color);
@@ -110,11 +109,14 @@ ul.tabs li.selected {
   @apply block mb-2;
 }
 
-
 .arch {
   @apply p-0 m-0 pt-4;
 }
 .arch .contents {
   @apply pt-4;
   min-height: 7rem;
+}
+
+.mobile-download {
+  @apply block sm:hidden mx-auto mb-12;
 }

--- a/src/site/artifacts/installers.rs
+++ b/src/site/artifacts/installers.rs
@@ -82,14 +82,17 @@ pub fn build_header(release: &Release, config: &Config) -> Result<Box<div<String
         "bottom-options"
     };
     Ok(html!(
-    <div class="artifacts" data-tag=tag>
-        {main_html}
-        {no_autodetect}
-        {noscript}
-        <div class=bottom_classes>
-            <a href=&downloads_href class="backup-download primary">{text!("View all installation options")}</a>
-            {selector}
+    <div>
+        <div class="artifacts" data-tag=tag>
+            {main_html}
+            {no_autodetect}
+            {noscript}
+            <div class=bottom_classes>
+                <a href=&downloads_href class="backup-download primary">{text!("View all installation options")}</a>
+                {selector}
+            </div>
         </div>
+        <a href=&downloads_href class="button mobile-download primary">{text!("View all installation options")}</a>
     </div>
     ))
 }

--- a/src/site/artifacts/installers.rs
+++ b/src/site/artifacts/installers.rs
@@ -17,6 +17,7 @@ pub fn build_header(release: &Release, config: &Config) -> Result<Box<div<String
     let downloads_href = link::generate(&config.build.path_prefix, "artifacts/");
     let tag = release.source.version_tag();
     let platforms_we_want = filter_platforms(release);
+    let view_all_text = "View all installation options";
 
     let simple_platforms = platforms_we_want.len() <= 1;
 
@@ -42,7 +43,7 @@ pub fn build_header(release: &Release, config: &Config) -> Result<Box<div<String
         None
     } else {
         Some(
-            html!(<noscript><a href=&downloads_href class="backup-download primary">{text!("View all installation options")}</a></noscript>),
+            html!(<noscript><a href=&downloads_href class="backup-download primary">{text!(view_all_text)}</a></noscript>),
         )
     };
     // If there's only one platform we don't need dropdowns
@@ -88,11 +89,11 @@ pub fn build_header(release: &Release, config: &Config) -> Result<Box<div<String
             {no_autodetect}
             {noscript}
             <div class=bottom_classes>
-                <a href=&downloads_href class="backup-download primary">{text!("View all installation options")}</a>
+                <a href=&downloads_href class="backup-download primary">{text!(view_all_text)}</a>
                 {selector}
             </div>
         </div>
-        <a href=&downloads_href class="button mobile-download primary">{text!("View all installation options")}</a>
+        <a href=&downloads_href class="button mobile-download primary">{text!(view_all_text)}</a>
     </div>
     ))
 }


### PR DESCRIPTION
Hides the widget on mobile and simply shows a button that takes you to the install page

<img width="440" alt="CleanShot 2023-06-26 at 18 22 13@2x" src="https://github.com/axodotdev/oranda/assets/1051509/c4fdddac-4559-49b1-82fd-f0fee07f5b20">


closes https://github.com/axodotdev/oranda/issues/435