### PR TITLE
fix: support subdirectories for additional pages paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,6 +2138,7 @@ dependencies = [
  "minifier",
  "notify-debouncer-mini",
  "octolotl",
+ "pathdiff",
  "reqwest",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ notify-debouncer-mini = "0.3.0"
 toml_edit = "0.19.9"
 schemars = { version = "0.8.12", features = ["indexmap1"] }
 indexmap = { version = "1.9.3", features = ["serde-1"] }
+pathdiff = { version = "0.2.1", features = ["camino"] }
 
 [dev-dependencies]
 assert_cmd="2"

--- a/src/site/layout/header.rs
+++ b/src/site/layout/header.rs
@@ -53,11 +53,10 @@ fn nav(
         Message::new(MessageType::Info, "Found additional pages...").print();
         for (page_name, page_path) in additional_pages.iter() {
             if page::source::is_markdown(page_path) {
-                let file_path = page::source::get_filename(page_path);
+                let file_path = page::source::get_filename_with_dir(page_path);
 
                 if let Some(file_name) = file_path {
-                    let href =
-                        link::generate(path_prefix, &format!("{}/", file_name.to_string_lossy()));
+                    let href = link::generate(path_prefix, &format!("{}/", file_name));
 
                     html.extend(html!(<li><a href=href>{text!(page_name)}</a></li>));
                 } else {

--- a/src/site/layout/header.rs
+++ b/src/site/layout/header.rs
@@ -53,7 +53,7 @@ fn nav(
         Message::new(MessageType::Info, "Found additional pages...").print();
         for (page_name, page_path) in additional_pages.iter() {
             if page::source::is_markdown(page_path) {
-                let file_path = page::source::get_filename_with_dir(page_path);
+                let file_path = page::source::get_filename_with_dir(page_path)?;
 
                 if let Some(file_name) = file_path {
                     let href = link::generate(path_prefix, &format!("{}/", file_name));

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -117,7 +117,8 @@ impl Site {
         let mut pages = vec![];
         for file_path in files.values() {
             if page::source::is_markdown(file_path) {
-                let additional_page = Page::new_from_file(file_path, layout_template, config)?;
+                let additional_page =
+                    Page::new_from_file_with_dir(file_path, layout_template, config)?;
                 pages.push(additional_page)
             } else {
                 let msg = format!(

--- a/src/site/page/mod.rs
+++ b/src/site/page/mod.rs
@@ -60,6 +60,22 @@ impl Page {
         })
     }
 
+    pub fn new_from_file_with_dir(source: &str, layout: &Layout, config: &Config) -> Result<Self> {
+        let body = Self::load_and_render_contents(source, &config.styles.syntax_theme)?;
+        let contents = layout.render(body, None);
+        // Try diffing with the execution directory in case the user has provided an absolute-ish
+        // path, in order to obtain the relative-to-dir path segment
+        let relpath = if let Some(path) = pathdiff::diff_paths(source, std::env::current_dir()?) {
+            path
+        } else {
+            source.into()
+        };
+        Ok(Page {
+            contents,
+            filename: relpath.display().to_string(),
+        })
+    }
+
     pub fn new_from_contents(
         body: String,
         filename: &str,

--- a/src/site/page/source.rs
+++ b/src/site/page/source.rs
@@ -1,3 +1,4 @@
+use camino::Utf8PathBuf;
 use std::{ffi::OsStr, path::Path};
 
 pub fn is_markdown(file: &str) -> bool {
@@ -11,4 +12,22 @@ pub fn is_markdown(file: &str) -> bool {
 pub fn get_filename(file: &str) -> Option<&OsStr> {
     let file_path = Path::new(file);
     file_path.file_stem()
+}
+
+pub fn get_filename_with_dir(file: &str) -> Option<Utf8PathBuf> {
+    let cur_dir = match std::env::current_dir() {
+        Ok(dir) => dir,
+        Err(_) => return None,
+    };
+    // Try diffing with the execution directory in case the user has provided an absolute-ish
+    // path, in order to obtain the relative-to-dir path segment
+    let path = if let Some(path) =
+        pathdiff::diff_utf8_paths(file, Utf8PathBuf::from_path_buf(cur_dir).unwrap())
+    {
+        path
+    } else {
+        Utf8PathBuf::from(file)
+    };
+
+    Some(path.with_extension(""))
 }

--- a/tests/build/fixtures/oranda_config.rs
+++ b/tests/build/fixtures/oranda_config.rs
@@ -8,10 +8,8 @@ use oranda::site::javascript::analytics::Plausible;
 
 pub fn no_artifacts(temp_dir: String) -> Config {
     let mut additional_pages = IndexMap::new();
-    additional_pages.insert(
-        "Another Page".to_string(),
-        "https://raw.githubusercontent.com/axodotdev/oranda/main/README.md".to_string(),
-    );
+    additional_pages.insert("Another Page".to_string(), "docs/src/cli.md".to_string());
+    additional_pages.insert("A New Page".to_string(), "SECURITY.md".to_string());
     Config {
         project: ProjectConfig {
             description: Some(String::from("you axolotl questions")),

--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -107,7 +107,7 @@ fn creates_nav() {
     let layout = Layout::new(&config).unwrap();
     let page = page::index(&config, &layout);
     eprintln!("{}", page.contents);
-    assert!(page.contents.contains(r#"<nav class="nav"><ul><li><a href="/">Home</a></li><li><a href="/README/">Another Page</a></li></ul></nav>"#));
+    assert!(page.contents.contains(r#"<nav class="nav"><ul><li><a href="/">Home</a></li><li><a href="/docs/src/cli/">Another Page</a></li><li><a href="/SECURITY/">A New Page</a></li></ul></nav>"#));
 }
 
 #[test]


### PR DESCRIPTION
```
{
  "build": {
    "additional_pages": {
      "Subpage": "subdir/mypage.md",
    }
  }
}
```

now builds and links to a page at `yoursiteurl.com/subdir/mypage`. Closes #448.