### PR TITLE
[WIP] Add install-widget to release pages

### DIFF
--- a/src/site/artifacts/mod.rs
+++ b/src/site/artifacts/mod.rs
@@ -66,11 +66,16 @@ pub fn scripts(release: &Release, config: &Config) -> Result<Vec<Box<div<String>
     Ok(output)
 }
 
-pub fn header(context: &Context, config: &Config) -> Result<String> {
+/// Build the install-widget for the latest release
+pub fn header(context: &Context, config: &Config) -> Result<Box<div<String>>> {
     let Some(release) = context.latest() else {
-        return Ok(String::new());
+        return Ok(html!(<div></div>));
     };
 
-    let header = installers::build_header(release, config)?;
-    Ok(header.to_string())
+    header_for_release(release, config)
+}
+
+/// Build the install-widget for a given release
+pub fn header_for_release(release: &Release, config: &Config) -> Result<Box<div<String>>> {
+    installers::build_header(release, config)
 }

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -66,9 +66,22 @@ pub fn build_single_release(config: &Config, release: &Release) -> Result<String
         .name()
         .unwrap_or(release.source.version_tag());
 
+    let artifacts_enabled = config
+        .components
+        .artifacts
+        .as_ref()
+        .map(|a| a.has_some())
+        .unwrap_or(false);
+    let widget = if artifacts_enabled {
+        Some(crate::site::artifacts::header_for_release(release, config)?)
+    } else {
+        None
+    };
+
     Ok(html!(
          <div>
             <h1>{text!("{}", title)}</h1>
+            {widget}
             <div class="releases-body">
                 {preview}
             </div>

--- a/src/site/page/mod.rs
+++ b/src/site/page/mod.rs
@@ -25,7 +25,7 @@ impl Page {
         layout: &Layout,
         config: &Config,
     ) -> Result<Self> {
-        let mut body = artifacts::header(context, config)?;
+        let mut body = artifacts::header(context, config)?.to_string();
         let readme = Self::load_and_render_contents(
             &config.project.readme_path,
             &config.styles.syntax_theme,


### PR DESCRIPTION
This uses the fact that the install-widget was always release-specific, so we can generate different copies for every install page