### PR TITLE
WIP: rewrite relative links to additional pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![release](https://github.com/axodotdev/oranda/actions/workflows/release.yml/badge.svg)](https://github.com/axodotdev/oranda/actions/workflows/release.yml)
 [![web](https://github.com/axodotdev/oranda/actions/workflows/web.yml/badge.svg?branch=main)](https://github.com/axodotdev/oranda/actions/workflows/web.yml)
 
+See [security](./SECURITY.md)
 
 `oranda` is an opinionated static-site generator that is designed for developers
 who are publishing projects and would like a website but don't want to build

--- a/oranda.json
+++ b/oranda.json
@@ -1,6 +1,9 @@
 {
   "build": {
-    "path_prefix": "oranda"
+    "path_prefix": "oranda",
+    "additional_pages": {
+      "security": "SECURITY.md"
+    }
   },
   "styles": {
     "theme": "axodark",

--- a/src/data/funding.rs
+++ b/src/data/funding.rs
@@ -41,7 +41,11 @@ pub enum FundingContent {
 
 impl Funding {
     /// Creates a new Funding struct by attempting to read from the FUNDING.yml, and the docs file.
-    pub fn new(funding_cfg: &FundingConfig, style_cfg: &StyleConfig) -> Result<Self> {
+    pub fn new(
+        path_prefix: &Option<String>,
+        funding_cfg: &FundingConfig,
+        style_cfg: &StyleConfig,
+    ) -> Result<Self> {
         let mut funding = if let Some(yml_path) = &funding_cfg.yml_path {
             match LocalAsset::load_string(yml_path) {
                 Ok(res) => {
@@ -66,7 +70,7 @@ impl Funding {
 
         if let Some(md_path) = &funding_cfg.md_path {
             let res = LocalAsset::load_string(md_path)?;
-            let html = to_html(&res, &style_cfg.syntax_theme)?;
+            let html = to_html(&res, &style_cfg.syntax_theme, path_prefix)?;
             funding.docs_content = Some(html);
         }
 

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -131,7 +131,11 @@ fn build_release_body(release: &Release, config: &Config) -> Result<String> {
         release.source.body().unwrap_or_default().to_owned()
     };
 
-    markdown::to_html(&contents, &config.styles.syntax_theme)
+    markdown::to_html(
+        &contents,
+        &config.styles.syntax_theme,
+        &config.build.path_prefix,
+    )
 }
 
 fn build_prerelease_toggle(has_prereleases: bool) -> Option<Box<div<String>>> {

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -89,7 +89,7 @@ impl Site {
                 pages.append(&mut changelog_pages);
             }
             if let Some(funding_cfg) = &config.components.funding {
-                let funding = Funding::new(funding_cfg, &config.styles)?;
+                let funding = Funding::new(&config.build.path_prefix, funding_cfg, &config.styles)?;
                 let body = funding::page(config, &funding)?;
                 let page = Page::new_from_contents(body, "funding.html", &layout_template, config);
                 pages.push(page);

--- a/src/site/page/mod.rs
+++ b/src/site/page/mod.rs
@@ -29,6 +29,7 @@ impl Page {
         let readme = Self::load_and_render_contents(
             &config.project.readme_path,
             &config.styles.syntax_theme,
+            &config.build.path_prefix,
         )?;
         body.push_str(&readme);
         let os_script = javascript::build_os_script(&config.build.path_prefix);
@@ -43,6 +44,7 @@ impl Page {
         let body = Self::load_and_render_contents(
             &config.project.readme_path,
             &config.styles.syntax_theme,
+            &config.build.path_prefix,
         )?;
         let contents = layout.render(body, None);
         Ok(Page {
@@ -52,7 +54,11 @@ impl Page {
     }
 
     pub fn new_from_file(source: &str, layout: &Layout, config: &Config) -> Result<Self> {
-        let body = Self::load_and_render_contents(source, &config.styles.syntax_theme)?;
+        let body = Self::load_and_render_contents(
+            source,
+            &config.styles.syntax_theme,
+            &config.build.path_prefix,
+        )?;
         let contents = layout.render(body, None);
         Ok(Page {
             contents,
@@ -61,7 +67,11 @@ impl Page {
     }
 
     pub fn new_from_file_with_dir(source: &str, layout: &Layout, config: &Config) -> Result<Self> {
-        let body = Self::load_and_render_contents(source, &config.styles.syntax_theme)?;
+        let body = Self::load_and_render_contents(
+            source,
+            &config.styles.syntax_theme,
+            &config.build.path_prefix,
+        )?;
         let contents = layout.render(body, None);
         // Try diffing with the execution directory in case the user has provided an absolute-ish
         // path, in order to obtain the relative-to-dir path segment
@@ -90,10 +100,14 @@ impl Page {
         }
     }
 
-    fn load_and_render_contents(source: &str, syntax_theme: &SyntaxTheme) -> Result<String> {
+    fn load_and_render_contents(
+        source: &str,
+        syntax_theme: &SyntaxTheme,
+        path_prefix: &Option<String>,
+    ) -> Result<String> {
         let source = SourceFile::load_local(source)?;
         let contents = source.contents();
-        markdown::to_html(contents, syntax_theme).map(|html| {
+        markdown::to_html(contents, syntax_theme, path_prefix).map(|html| {
             let html: Box<div<String>> = html!(
                 <div class="rendered-markdown">
                     {unsafe_text!(html)}

--- a/tests/build/fixtures/page.rs
+++ b/tests/build/fixtures/page.rs
@@ -39,7 +39,12 @@ fn reset(dist_dir: &str) {
 
 pub fn index(config: &Config, layout: &Layout) -> Page {
     reset(&config.build.dist_dir);
-    let body = markdown::to_html(readme(), &config.styles.syntax_theme).unwrap();
+    let body = markdown::to_html(
+        readme(),
+        &config.styles.syntax_theme,
+        &config.build.path_prefix,
+    )
+    .unwrap();
     Page::new_from_contents(body, "index.html", layout, config)
 }
 
@@ -60,7 +65,12 @@ pub fn index_with_artifacts(config: &Config, layout: &Layout) -> Page {
 
 pub fn index_with_warning(config: &Config, layout: &Layout) -> Page {
     reset(&config.build.dist_dir);
-    let body = markdown::to_html(readme_invalid_annotation(), &config.styles.syntax_theme).unwrap();
+    let body = markdown::to_html(
+        readme_invalid_annotation(),
+        &config.styles.syntax_theme,
+        &config.build.path_prefix,
+    )
+    .unwrap();
     Page::new_from_contents(body, "index.html", layout, config)
 }
 


### PR DESCRIPTION
this is currently hardcoded to SECURITY.md, and needs a more robust notion of relative links to pages we care about

(also this temporarily adjusts the repo to give a test case)