### PR TITLE
fix logo position

### DIFF
--- a/oranda-css/css/base.css
+++ b/oranda-css/css/base.css
@@ -213,7 +213,7 @@ main {
 }
 
 .logo {
-  @apply m-auto;
+  @apply m-auto block max-w-xs;
 }
 
 .inline-code {

--- a/oranda-css/css/themes/hacker.css
+++ b/oranda-css/css/themes/hacker.css
@@ -33,6 +33,7 @@ html.hacker h6 {
 html.hacker .repo_banner > a,
 html.hacker footer {
   color: var(--light-color);
+  @apply py-2;
 }
 
 html.hacker p,
@@ -125,4 +126,8 @@ html.hacker .artifacts {
 
 html.hacker .published-date {
   @apply block w-full;
+}
+
+html.hacker .logo {
+  @apply block m-0;
 }

--- a/oranda.json
+++ b/oranda.json
@@ -3,6 +3,7 @@
     "path_prefix": "oranda"
   },
   "styles": {
+    "logo": "https://doc.rust-lang.org/cargo/images/Cargo-Logo-Small.png",
     "theme": "axodark",
     "favicon": "https://www.axo.dev/favicon.ico"
   },

--- a/oranda.json
+++ b/oranda.json
@@ -3,7 +3,6 @@
     "path_prefix": "oranda"
   },
   "styles": {
-    "logo": "https://doc.rust-lang.org/cargo/images/Cargo-Logo-Small.png",
     "theme": "axodark",
     "favicon": "https://www.axo.dev/favicon.ico"
   },


### PR DESCRIPTION
This PR fixes the lacking css on the logo position by making it center and also providing a max width of 320px to make sure you can pluck any logo and it won't be too big

<img width="1392" alt="CleanShot 2023-07-06 at 09 53 18@2x" src="https://github.com/axodotdev/oranda/assets/1051509/8c83e595-20ff-4a6c-84bd-bc2683163089">


One consideration is that the logo was left on the left in the hacker theme since the text is also aligned to the left

<img width="1351" alt="CleanShot 2023-07-06 at 09 52 56@2x" src="https://github.com/axodotdev/oranda/assets/1051509/ed285e8d-056f-4314-a50e-d1b8cf0b20d5">




closes https://github.com/axodotdev/oranda/issues/519