### PR TITLE
fix: misc workspace fixes

### DIFF
--- a/src/config/components/funding.rs
+++ b/src/config/components/funding.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::config::{ApplyLayer, ApplyOptExt};
 use crate::data::funding::FundingType;
@@ -59,7 +59,7 @@ impl ApplyLayer for FundingConfig {
 
 impl FundingConfig {
     /// If we have a FUNDING.yml file, try to find it. If we fail, we disable funding support.
-    pub fn find_paths(config: &mut Option<Self>, start_dir: &PathBuf) -> Result<()> {
+    pub fn find_paths(config: &mut Option<Self>, start_dir: &Path) -> Result<()> {
         // If this is None, we were force-disabled and shouldn't auto-detect
         let Some(this) = config else {
             return Ok(())

--- a/src/config/components/funding.rs
+++ b/src/config/components/funding.rs
@@ -1,6 +1,7 @@
 use camino::Utf8PathBuf;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use std::path::PathBuf;
 
 use crate::config::{ApplyLayer, ApplyOptExt};
 use crate::data::funding::FundingType;
@@ -58,7 +59,7 @@ impl ApplyLayer for FundingConfig {
 
 impl FundingConfig {
     /// If we have a FUNDING.yml file, try to find it. If we fail, we disable funding support.
-    pub fn find_paths(config: &mut Option<Self>) -> Result<()> {
+    pub fn find_paths(config: &mut Option<Self>, start_dir: &PathBuf) -> Result<()> {
         // If this is None, we were force-disabled and shouldn't auto-detect
         let Some(this) = config else {
             return Ok(())
@@ -66,14 +67,15 @@ impl FundingConfig {
 
         // Try to auto-detect the FUNDING.yml if not specified
         if this.yml_path.is_none() {
-            let default_yml_path = Utf8PathBuf::from("./.github/FUNDING.yml");
+            let default_yml_path =
+                Utf8PathBuf::from(format!("{}/.github/FUNDING.yml", start_dir.display()));
             if default_yml_path.exists() {
                 this.yml_path = Some(default_yml_path.to_string());
             }
         }
         // Try to auto-detect funding.md if not specified
         if this.md_path.is_none() {
-            let default_md_path = Utf8PathBuf::from("./funding.md");
+            let default_md_path = Utf8PathBuf::from(format!("{}/funding.md", start_dir.display()));
             if default_md_path.exists() {
                 this.md_path = Some(default_md_path.to_string());
             }

--- a/src/config/components/mdbooks.rs
+++ b/src/config/components/mdbooks.rs
@@ -1,7 +1,7 @@
 use camino::Utf8PathBuf;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::config::{ApplyLayer, ApplyOptExt, ApplyValExt};
 use crate::errors::*;
@@ -75,7 +75,7 @@ impl MdBookConfig {
     /// If mdbook is enabled but the path isn't set, we try to find it
     ///
     /// If we fail, we set mdbook to None to disable it.
-    pub fn find_paths(config: &mut Option<MdBookConfig>, start_dir: &PathBuf) -> Result<()> {
+    pub fn find_paths(config: &mut Option<MdBookConfig>, start_dir: &Path) -> Result<()> {
         // If this is None, we were force-disabled and shouldn't auto-detect
         let Some(this) = config else {
             return Ok(());
@@ -86,7 +86,7 @@ impl MdBookConfig {
             let possible_paths: Vec<String> = vec!["/", "book/", "docs/"]
                 .iter()
                 .map(|p| {
-                    let mut path = start_dir.clone();
+                    let mut path = start_dir.to_path_buf();
                     path.push(p);
                     path.display().to_string()
                 })
@@ -95,7 +95,7 @@ impl MdBookConfig {
                 let book_path = Utf8PathBuf::from(&book_dir).join("book.toml");
                 if book_path.exists() {
                     // nice, use it
-                    this.path = Some(book_dir.to_owned());
+                    this.path = Some(book_dir);
                     return Ok(());
                 }
             }

--- a/src/config/components/mdbooks.rs
+++ b/src/config/components/mdbooks.rs
@@ -1,6 +1,7 @@
 use camino::Utf8PathBuf;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use std::path::PathBuf;
 
 use crate::config::{ApplyLayer, ApplyOptExt, ApplyValExt};
 use crate::errors::*;
@@ -74,7 +75,7 @@ impl MdBookConfig {
     /// If mdbook is enabled but the path isn't set, we try to find it
     ///
     /// If we fail, we set mdbook to None to disable it.
-    pub fn find_paths(config: &mut Option<MdBookConfig>) -> Result<()> {
+    pub fn find_paths(config: &mut Option<MdBookConfig>, start_dir: &PathBuf) -> Result<()> {
         // If this is None, we were force-disabled and shouldn't auto-detect
         let Some(this) = config else {
             return Ok(());
@@ -82,9 +83,16 @@ impl MdBookConfig {
 
         if this.path.is_none() {
             // Ok time to auto-detect, try these dirs for a book.toml
-            let possible_paths = vec!["./", "./book/", "./docs/"];
+            let possible_paths: Vec<String> = vec!["/", "book/", "docs/"]
+                .iter()
+                .map(|p| {
+                    let mut path = start_dir.clone();
+                    path.push(p);
+                    path.display().to_string()
+                })
+                .collect();
             for book_dir in possible_paths {
-                let book_path = Utf8PathBuf::from(book_dir).join("book.toml");
+                let book_path = Utf8PathBuf::from(&book_dir).join("book.toml");
                 if book_path.exists() {
                     // nice, use it
                     this.path = Some(book_dir.to_owned());

--- a/src/data/workspaces.rs
+++ b/src/data/workspaces.rs
@@ -29,8 +29,13 @@ pub fn from_config(
         let path = Utf8PathBuf::from(member.path.display().to_string()).canonicalize_utf8()?;
         let mut config_path = path.clone();
         config_path.push("oranda.json");
-        let mut config =
-            Config::build_workspace_member(&config_path, workspace_config_path, &path)?;
+        let mut config = Config::build_workspace_member(
+            &config_path,
+            workspace_config_path,
+            &path,
+            &member,
+            Some(member.slug.clone()),
+        )?;
 
         // Set the correct path prefix. This should be:
         // - If no root path prefix: `slug`

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -120,7 +120,12 @@ where
 
             if let Some(fields) = fields {
                 if let Some(prefix) = fields.prefix {
-                    write!(&mut writer, "[{}] {}", prefix, output_str)?;
+                    write!(
+                        &mut writer,
+                        "{:>15} {}",
+                        console::style(prefix).magenta(),
+                        output_str
+                    )?;
                 } else {
                     write!(&mut writer, "{}", output_str)?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,10 @@ struct Cli {
     #[clap(subcommand)]
     command: Command,
 
-    /// How verbose logging should be (log level)
-    #[clap(long)]
-    #[clap(default_value_t = LevelFilter::WARN)]
-    #[clap(value_parser = PossibleValuesParser::new(["off", "error", "warn", "info", "debug", "trace"]).map(|s| s.parse::<LevelFilter>().expect("possible values are valid")))]
+    /// Whether to output more detailed debug information
+    #[clap(short, long)]
     #[clap(help_heading = "GLOBAL OPTIONS", global = true)]
-    pub verbose: LevelFilter,
+    pub verbose: bool,
 
     /// The format of the output
     #[clap(long, value_enum)]
@@ -47,7 +45,6 @@ fn main() {
     let cli = Cli::parse();
 
     axocli::CliAppBuilder::new("oranda")
-        .verbose(cli.verbose)
         .json_errors(cli.output_format == OutputFormat::Json)
         .start(cli, run);
 }
@@ -60,7 +57,12 @@ fn run(cli: &axocli::CliApp<Cli>) -> Result<(), Report> {
         .build()
         .expect("Initializing tokio runtime failed");
     let _guard = runtime.enter();
-    let sub_filter = tracing_subscriber::filter::Targets::new().with_target("oranda", Level::INFO);
+    let log_level = if cli.config.verbose {
+        Level::DEBUG
+    } else {
+        Level::INFO
+    };
+    let sub_filter = tracing_subscriber::filter::Targets::new().with_target("oranda", log_level);
     let sub = tracing_subscriber::registry()
         .with(formatter::CaptureFieldsLayer)
         .with(tracing_subscriber::fmt::layer().event_format(formatter::OrandaFormatter))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::uninlined_format_args)]
 
-use clap::builder::{PossibleValuesParser, TypedValueParser};
 use clap::{Parser, Subcommand};
 use miette::Report;
-use tracing::level_filters::LevelFilter;
 use tracing::subscriber::set_default;
 use tracing::Level;
 use tracing_subscriber::layer::SubscriberExt;


### PR DESCRIPTION
- Fixed autodetection always working from the workspace root. It now starts from a workspace member directory
- Changed the `--verbose LEVEL` option into a regular `--verbose` bool flag that enables debug output when set (this warrants a changelog entry for sure)
- The prefixes now print in a proper offset and nicely colored style