### PR TITLE
feat: implement workspace autodetection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,6 +1984,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "slug",
  "syntect",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ indexmap = { version = "1.9.3", features = ["serde-1"] }
 pathdiff = { version = "0.2.1", features = ["camino"] }
 minijinja = { version = "1.0.3", features = ["loader"] }
 include_dir = "0.7.3"
+slug = "0.1.4"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/config/axoproject.rs
+++ b/src/config/axoproject.rs
@@ -20,7 +20,8 @@ pub struct AxoprojectLayer {
 impl AxoprojectLayer {
     /// Load package information about a single-package workspace, where the package is equal to the
     /// current working dir. This is in opposition to our workspace support, which needs to be
-    /// explicitly enabled. Used like this, we don't use axoproject's workspace-y features at all.
+    /// explicitly enabled. axoproject is workspace-aware, but we don't use the multi-package
+    /// workspace functionality it gives us when ran like this.
     pub fn load(project_root: Option<PathBuf>) -> Result<Option<AxoprojectLayer>> {
         // Start in the project root, or failing that current dir
         let start_dir = project_root.unwrap_or_else(|| {

--- a/src/config/axoproject.rs
+++ b/src/config/axoproject.rs
@@ -1,3 +1,4 @@
+use crate::config::workspace::WorkspaceMember;
 use axoproject::{PackageIdx, WorkspaceInfo, WorkspaceSearch};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::path::PathBuf;
@@ -9,12 +10,17 @@ use crate::errors::*;
 #[derive(Debug)]
 pub struct AxoprojectLayer {
     /// Generic project info
-    pub project: ProjectLayer,
+    pub project: Option<ProjectLayer>,
     /// Did they have cargo_dist settings?
     pub cargo_dist: Option<bool>,
+    /// Information about workspace packages
+    pub members: Option<Vec<WorkspaceMember>>,
 }
 
 impl AxoprojectLayer {
+    /// Load package information about a single-package workspace, where the package is equal to the
+    /// current working dir. This is in opposition to our workspace support, which needs to be
+    /// explicitly enabled. Used like this, we don't use axoproject's workspace-y features at all.
     pub fn load(project_root: Option<PathBuf>) -> Result<Option<AxoprojectLayer>> {
         // Start in the project root, or failing that current dir
         let start_dir = project_root.unwrap_or_else(|| {
@@ -22,7 +28,13 @@ impl AxoprojectLayer {
         });
         let start_dir = Utf8PathBuf::from_path_buf(start_dir).expect("project path isn't utf8!?");
 
-        if let Some((workspace, pkg)) = AxoprojectLayer::get_project(&start_dir) {
+        let workspace = Self::get_best_workspace(&start_dir);
+        let Some(workspace) = workspace else {
+            return Ok(None);
+        };
+        let project = Self::get_root_package(&start_dir, workspace);
+
+        if let Some((workspace, pkg)) = project {
             // Cool we found the best possible match, now extract all the values we care about from it
             let package = workspace.package(pkg);
 
@@ -33,7 +45,7 @@ impl AxoprojectLayer {
                 .as_ref()
                 .map(|t| t.get("dist").is_some());
             Ok(Some(AxoprojectLayer {
-                project: ProjectLayer {
+                project: Some(ProjectLayer {
                     name: Some(package.name.clone()),
                     description: package.description.clone(),
                     homepage: package.homepage_url.clone(),
@@ -41,113 +53,96 @@ impl AxoprojectLayer {
                     version: package.version.as_ref().map(|v| v.to_string()),
                     license: package.license.clone(),
                     readme_path: package.readme_file.as_ref().map(|v| v.to_string()),
-                },
+                }),
                 cargo_dist,
+                members: None,
             }))
         } else {
             Ok(None)
         }
     }
 
-    /// Get information about the project workspace (using axoproject)
-    ///
-    /// The returned value is info about a Workspace and the specific package in that
-    /// workspace that "owns" the start_dir.
-    ///
-    /// Various warnings will be emitted for situations that Almost Match but are
-    /// rejected for one reason or another.
-    pub fn get_project(start_dir: &Utf8Path) -> Option<(WorkspaceInfo, PackageIdx)> {
+    /// Load packages from an actual workspace. This is in contract to `load`, which only collects
+    /// information about one package. Here, we simply collect workspace metadata for every
+    /// found workspace member.
+    pub fn load_workspace(project_root: &Utf8Path) -> Result<Option<AxoprojectLayer>> {
+        // Just ignore the package this function picks out for us. We want all packages instead
+        let Some(workspace) = Self::get_best_workspace(project_root) else {
+            return Ok(None);
+        };
+
+        // Gimme all packages!
+        let mut members = Vec::new();
+        for (_, package) in workspace.packages() {
+            let member = WorkspaceMember {
+                path: package.package_root.clone().into(),
+                slug: slug::slugify(package.name.clone()),
+            };
+            members.push(member);
+        }
+
+        Ok(Some(AxoprojectLayer {
+            project: None,
+            cargo_dist: None,
+            members: Some(members),
+        }))
+    }
+
+    /// Given context, fetches workspaces and returns whichever "wins". Right now, this means Cargo
+    /// projects always win over JS projects, but this will change in the future as we introduce more
+    /// criteria.
+    pub fn get_best_workspace(start_dir: &Utf8Path) -> Option<WorkspaceInfo> {
         // Clamp the search for project files to the the start dir, because oranda
         // wants to work in so many different situations that things get muddy very quickly
         let clamp_to_dir = start_dir;
 
         // Search for workspaces and process the results
         let workspaces = axoproject::get_workspaces(start_dir, Some(clamp_to_dir));
-        let rust_workspace = Self::handle_search_result(start_dir, workspaces.rust, "rust");
-        let js_workspace =
-            Self::handle_search_result(start_dir, workspaces.javascript, "javascript");
+        let rust_workspace = Self::handle_search_result(workspaces.rust, "rust");
+        let js_workspace = Self::handle_search_result(workspaces.javascript, "javascript");
 
         // Now pick the "best" one based on... absolutely nothing right now! Since we clamp to
         // one dir, all the parseable projects are on perfectly even footing, so we just
         // will always pick the Cargo.toml over the package.json. In the future we'll have
         // configs to disambiguate.
         let all_workspaces = vec![rust_workspace, js_workspace];
-        let mut best_workspace: Option<(WorkspaceInfo, PackageIdx)> = None;
+        let mut best_workspace: Option<WorkspaceInfo> = None;
         let mut rejected_workspaces = vec![];
         for workspace in all_workspaces {
-            let Some((workspace, pkg_idx)) = workspace else {
+            let Some(workspace) = workspace else {
                 continue;
             };
-            // In the future this will be some more complex criteria
-            // like "closest package" or "has an oranda config"
-            // For now the criteria is "first one wins"
+
+            // In the future this will be some more complex criteria like "closes package" or
+            // "has an oranda config", but for now the criteria is "first one wins".
             let is_better = best_workspace.is_none();
             if is_better {
                 if let Some(defeated) = best_workspace {
                     rejected_workspaces.push(defeated);
                 }
-                best_workspace = Some((workspace, pkg_idx));
+                best_workspace = Some(workspace);
             } else {
-                rejected_workspaces.push((workspace, pkg_idx));
+                rejected_workspaces.push(workspace);
             }
         }
 
-        if let Some((_, _best_pkg)) = &best_workspace {
-            // Report the winner
-            // let message = format!("Detected {:?} project...", best_ws.kind);
-            // Message::new(MessageType::Info, &message).print();
-            // tracing::info!("{}", message);
-
-            // Warn about the existence of perfectly good losers
-            for (reject_ws, reject_pkg) in rejected_workspaces {
-                let reject_pkg = reject_ws.package(reject_pkg);
-                let message = format!(
-                    "Also found a {:?} project at {}, but we're ignoring it",
-                    reject_ws.kind, reject_pkg.manifest_path
-                );
-                tracing::warn!("{}", &message);
-            }
+        // Warn about the existence of perfectly good losers
+        for reject_ws in rejected_workspaces {
+            let message = format!(
+                "Also found a {:?} project at {}, but we're ignoring it",
+                reject_ws.kind, reject_ws.manifest_path,
+            );
+            tracing::warn!("{}", &message);
         }
 
         best_workspace
     }
 
-    /// Process the raw result of axoproject to print warnings and choose the actual
-    /// package in the workspace that applies.
-    fn handle_search_result(
-        start_dir: &Utf8Path,
-        search: WorkspaceSearch,
-        name: &str,
-    ) -> Option<(WorkspaceInfo, PackageIdx)> {
+    /// Handles the `WorkspaceSearch` enum, emitting warnings for a bunch of cases.
+    fn handle_search_result(search: WorkspaceSearch, name: &str) -> Option<WorkspaceInfo> {
         match search {
-            axoproject::WorkspaceSearch::Found(workspace) => {
-                // Now that we found the workspace, find the actual package that appears
-                // in the dir we're looking at. We need to use canonicalize here because
-                // something in guppy/cargo is desugarring symlinks in their output, so
-                // we need to too.
-                let package = workspace.packages().find_map(|(idx, p)| {
-                    let package_dir = p
-                        .manifest_path
-                        .parent()
-                        .expect("project manifest file wasn't in a dir!?");
-                    if is_same_path(package_dir, start_dir) {
-                        Some(idx)
-                    } else {
-                        None
-                    }
-                });
-
-                if let Some(pkg_idx) = package {
-                    // Nice, this package is a perfect candidate
-                    Some((workspace, pkg_idx))
-                } else {
-                    // Found a workspace but none of the packages specifically control this dir.
-                    // This can happen if you run oranda in a dir with a virtual Cargo.toml.
-                    tracing::warn!("Ignoring {:?} project, oranda is currently per-package and this looks like a whole workspace", workspace.kind);
-                    None
-                }
-            }
-            axoproject::WorkspaceSearch::Broken {
+            WorkspaceSearch::Found(workspace) => Some(workspace),
+            WorkspaceSearch::Broken {
                 manifest_path,
                 cause,
             } => {
@@ -159,15 +154,40 @@ impl AxoprojectLayer {
                 eprintln!("{:?}", miette::Report::new(warning));
                 None
             }
-            axoproject::WorkspaceSearch::Missing(cause) => {
-                // Just quietly log this in case it's useful
-                tracing::debug!(
+            WorkspaceSearch::Missing(cause) => {
+                // Just quietly debug log this in case it's useful
+                tracing::trace!(
                     "Couldn't find a {name} project: {:?}",
                     &miette::Report::new(cause)
                 );
                 None
             }
         }
+    }
+
+    /// Given a workspace, tries to find the "root" package that's contained in the same directory
+    /// as the workspace root.
+    fn get_root_package(
+        start_dir: &Utf8Path,
+        workspace: WorkspaceInfo,
+    ) -> Option<(WorkspaceInfo, PackageIdx)> {
+        // Now that we found the workspace, find the actual package that appears
+        // in the dir we're looking at. We need to use canonicalize here because
+        // something in guppy/cargo is desugarring symlinks in their output, so
+        // we need to too.
+        let package = workspace.packages().find_map(|(idx, p)| {
+            let package_dir = p
+                .manifest_path
+                .parent()
+                .expect("project manifest file wasn't in a dir!?");
+            if is_same_path(package_dir, start_dir) {
+                Some(idx)
+            } else {
+                None
+            }
+        });
+
+        package.map(|pkg_idx| (workspace, pkg_idx))
     }
 }
 

--- a/src/config/oranda_config.rs
+++ b/src/config/oranda_config.rs
@@ -43,7 +43,7 @@ impl OrandaLayer {
                 Ok(Some(data))
             }
             Err(_) => {
-                tracing::info!("No config found, using default values");
+                tracing::debug!("No config found, using default values");
                 Ok(None)
             }
         }

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -11,9 +11,11 @@ pub struct WorkspaceLayer {
     pub name: Option<String>,
     /// A list of workspace members
     pub members: Option<Vec<WorkspaceMember>>,
+    /// Whether to enable workspace autodetection
+    pub auto: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Hash, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct WorkspaceMember {
     /// Slug for the generated URLs and directories
@@ -26,6 +28,7 @@ pub struct WorkspaceMember {
 pub struct WorkspaceConfig {
     pub name: Option<String>,
     pub members: Vec<WorkspaceMember>,
+    pub auto: bool,
 }
 
 impl Default for WorkspaceConfig {
@@ -33,6 +36,7 @@ impl Default for WorkspaceConfig {
         Self {
             name: Some("My Oranda Config".to_string()),
             members: Vec::new(),
+            auto: false,
         }
     }
 }
@@ -40,8 +44,13 @@ impl Default for WorkspaceConfig {
 impl ApplyLayer for WorkspaceConfig {
     type Layer = WorkspaceLayer;
     fn apply_layer(&mut self, layer: Self::Layer) {
-        let WorkspaceLayer { name, members } = layer;
+        let WorkspaceLayer {
+            name,
+            members,
+            auto,
+        } = layer;
         self.name.apply_opt(name);
         self.members.apply_val(members);
+        self.auto.apply_val(auto);
     }
 }

--- a/tests/config/mod.rs
+++ b/tests/config/mod.rs
@@ -16,7 +16,7 @@ fn it_detects_a_js_project() {
         .write_str(project_config::package_json())
         .expect("failed to write package_json");
 
-    let (ws, _pkg) = AxoprojectLayer::get_project(temppath).unwrap();
+    let ws = AxoprojectLayer::get_best_workspace(temppath).unwrap();
     assert_eq!(ws.kind, axoproject::WorkspaceKind::Javascript);
     tempdir
         .close()
@@ -35,10 +35,11 @@ fn it_loads_a_js_project_config() {
     let config = AxoprojectLayer::load(Some(tempdir.path().to_path_buf()))
         .expect("failed to load package.json")
         .unwrap();
+    let project = config.project.unwrap();
 
-    assert_eq!(config.project.name, Some("axo".to_owned()));
-    assert_eq!(config.project.description, Some(">o_o<".to_owned()));
-    assert_eq!(config.project.homepage, None);
+    assert_eq!(project.name, Some("axo".to_owned()));
+    assert_eq!(project.description, Some(">o_o<".to_owned()));
+    assert_eq!(project.homepage, None);
     tempdir
         .close()
         .expect("could not successfully delete temporary directory");
@@ -55,7 +56,7 @@ fn it_detects_a_rust_project() {
     let main = tempdir.child("src/main.rs");
     main.write_str(project_config::main_rs())
         .expect("failed to write main.rs");
-    let (ws, _pkg) = AxoprojectLayer::get_project(temppath).unwrap();
+    let ws = AxoprojectLayer::get_best_workspace(temppath).unwrap();
     assert_eq!(ws.kind, axoproject::WorkspaceKind::Rust);
     tempdir
         .close()
@@ -76,10 +77,11 @@ fn it_loads_a_rust_project_config() {
     let config = AxoprojectLayer::load(Some(tempdir.path().to_path_buf()))
         .expect("failed to load Cargo.toml")
         .unwrap();
+    let project = config.project.unwrap();
 
-    assert_eq!(config.project.name, Some("axo".to_owned()));
-    assert_eq!(config.project.description, Some("blublublub".to_owned()));
-    assert_eq!(config.project.version, Some("0.0.0".to_string()));
+    assert_eq!(project.name, Some("axo".to_owned()));
+    assert_eq!(project.description, Some("blublublub".to_owned()));
+    assert_eq!(project.version, Some("0.0.0".to_string()));
     tempdir
         .close()
         .expect("could not successfully delete temporary directory");
@@ -90,7 +92,7 @@ fn it_can_successfully_not_detect_a_project() {
     let tempdir = assert_fs::TempDir::new().expect("failed creating tempdir");
     let temppath = Utf8Path::from_path(tempdir.path()).expect("non-utf8 temp path");
 
-    assert!(AxoprojectLayer::get_project(temppath).is_none());
+    assert!(AxoprojectLayer::get_best_workspace(temppath).is_none());
     tempdir
         .close()
         .expect("could not successfully delete temporary directory");


### PR DESCRIPTION
Works via setting `workspaces.auto` to `true`. Manually listed workspace members override autodetected members (provided they have the same slug and path - it might be work manually implementing `PartialEq, Eq, Hash` for `WorkspaceMember`).

Depends on #540, closes #535.