### PR TITLE
fix: preserve workspace member ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f75e6f2b03d9292f6e18aaeeda21d58c91f6943a58ea19a2e8672dcf9d91d5b"
 dependencies = [
+ "indexmap 1.9.3",
  "memo-map",
  "self_cell",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ toml_edit = "0.19.9"
 schemars = { version = "0.8.12", features = ["indexmap1"] }
 indexmap = { version = "1.9.3", features = ["serde-1"] }
 pathdiff = { version = "0.2.1", features = ["camino"] }
-minijinja = { version = "1.0.3", features = ["loader"] }
+minijinja = { version = "1.0.3", features = ["loader", "preserve_order"] }
 include_dir = "0.7.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Turns out all we have to do for this is to enable the feature that causes `minijinja` to keep internal map representations as an `IndexMap`. This potentially also fixes some other arbitrary orderings in templates we haven't come across yet.