### PR TITLE
display the available platforms alphabetically

### DIFF
--- a/src/site/templates.rs
+++ b/src/site/templates.rs
@@ -6,7 +6,6 @@
 //! can also use features such as imports, inheritance, extends, and so on.
 
 use crate::config::Config;
-use crate::data::artifacts::inference::triple_to_display_name;
 use crate::errors::Result;
 use crate::site::layout::LayoutContext;
 use crate::site::markdown::SyntaxTheme;
@@ -42,7 +41,6 @@ impl<'a> Templates<'a> {
         }
         env.add_filter("generate_link", Self::generate_link);
         env.add_filter("syntax_highlight", Self::syntax_highlight);
-        env.add_filter("triple_to_display_name", Self::triple_to_display_name);
         // Use opt-in autoescape
         env.set_auto_escape_callback(|_| AutoEscape::None);
         let layout = LayoutContext::new(config)?;
@@ -113,12 +111,5 @@ impl<'a> Templates<'a> {
             Ok(res) => res,
             Err(_) => format!("<code class='inline-code'>{code}</code>"),
         }
-    }
-
-    // Turn a triple into a pretty display name, or return the original triple
-    fn triple_to_display_name(target: String) -> String {
-        triple_to_display_name(&target)
-            .map(|t| t.to_string())
-            .unwrap_or(target)
     }
 }

--- a/templates/includes/artifacts_header.html.j2
+++ b/templates/includes/artifacts_header.html.j2
@@ -10,11 +10,11 @@
         {% endif %}
 
         <ul class="arches">
-            {% for target, installers in artifacts.platforms_with_downloads|items %}
-                <li class="arch{% if not simple_platforms %} hidden{% endif %}" data-arch="{{ target }}">
-                    {% if installers | length > 1 %}
+            {% for platform in artifacts.platforms_with_downloads %}
+                <li class="arch{% if not simple_platforms %} hidden{% endif %}" data-arch="{{ platform.target }}">
+                    {% if platform.installers | length > 1 %}
                         <ul class="tabs">
-                            {% for i in installers %}
+                            {% for i in platform.installers %}
                                 {% set installer = artifacts.release.artifacts.installers[i] %}
                                 {# Select the first tab #}
                                 <li class="install-tab{% if simple_platforms and loop.first %} selected{% endif %}" data-id="{{ i }}" data-triple="{{ target }}">
@@ -25,9 +25,9 @@
                     {% endif %}
 
                     <ul class="contents">
-                        {% for i in installers %}
+                        {% for i in platform.installers %}
                             {% set installer = artifacts.release.artifacts.installers[i] %}
-                            <li data-id="{{ i }}" data-triple="{{ target }}" class="install-content{% if not simple_platforms and not loop.first %} hidden{% endif %}">
+                            <li data-id="{{ i }}" data-triple="{{ platform.target }}" class="install-content{% if not simple_platforms and not loop.first %} hidden{% endif %}">
                                 {% if installer.method.type == "Run" %}
                                     {% set release = artifacts.release %}
                                     {% include "includes/installer_run.html" %}
@@ -63,19 +63,19 @@
     <div class="mac-switch hidden">This project doesn't offer Apple Silicon downloads, but you can run Intel macOS binaries via Rosetta 2.</div>
 
     {# Get the first target from the first platform (convert the map into a list of KV lists, and then get the list head twice) #}
-    {% set first_target = artifacts.platforms_with_downloads | items | first | first %}
+    {% set first_target = artifacts.platforms_with_downloads | first | attr("target") %}
     <div class="bottom-options {% if simple_platforms and first_target != "all" %}one{% endif %}">
         <a href="{{ "artifacts/" | generate_link(layout.path_prefix) }}" class="backup-download primary">View all installation options</a>
         {% if simple_platforms %}
             {% if first_target and first_target != "all" %}
-                <div class="arch-select">Platform: {{ target | triple_to_display_name }}</div>
+                <div class="arch-select">Platform: {{ platform.display_name }}</div>
             {% endif %}
         {% else %}
             <div class="arch-select hidden">
                 <select id="install-arch-select">
                     <option disabled="true" selected="true" value=""></option>
-                    {% for target, v in artifacts.platforms_with_downloads | items %}
-                        <option value="{{ target }}">{{ target | triple_to_display_name }}</option>
+                    {% for platform in artifacts.platforms_with_downloads | sort(attribute = "display_name") %}
+                        <option value="{{ platform.target }}">{{ platform.display_name }}</option>
                     {% endfor %}
                 </select>
             </div>

--- a/templates/includes/artifacts_header.html.j2
+++ b/templates/includes/artifacts_header.html.j2
@@ -17,7 +17,7 @@
                             {% for i in platform.installers %}
                                 {% set installer = artifacts.release.artifacts.installers[i] %}
                                 {# Select the first tab #}
-                                <li class="install-tab{% if simple_platforms and loop.first %} selected{% endif %}" data-id="{{ i }}" data-triple="{{ target }}">
+                                <li class="install-tab{% if simple_platforms and loop.first %} selected{% endif %}" data-id="{{ i }}" data-triple="{{ platform.target }}">
                                     {{ installer.label }}
                                 </li>
                             {% endfor %}
@@ -62,7 +62,7 @@
     {% endif %}
     <div class="mac-switch hidden">This project doesn't offer Apple Silicon downloads, but you can run Intel macOS binaries via Rosetta 2.</div>
 
-    {# Get the first target from the first platform (convert the map into a list of KV lists, and then get the list head twice) #}
+    {# Get the target from the first platform #}
     {% set first_target = artifacts.platforms_with_downloads | first | attr("target") %}
     <div class="bottom-options {% if simple_platforms and first_target != "all" %}one{% endif %}">
         <a href="{{ "artifacts/" | generate_link(layout.path_prefix) }}" class="backup-download primary">View all installation options</a>


### PR DESCRIPTION
the main change is on line 77 of artifacts_header.html.j2, which is supported by refactoring the template context into a list that contains the display names we want to sort by. I've removed the filter as we don't need to generate display names within the template anymore.

closes #480 