### PR TITLE
feat: add option to toggle workspace index page

### DIFF
--- a/docs/src/configuration/workspaces.md
+++ b/docs/src/configuration/workspaces.md
@@ -56,6 +56,8 @@ workspace's members, as well as some quick info and metadata.
 ## List of workspace configuration keys
 
 - [name](#name) - set the overarching workspace name
+- [auto](#auto) - enable workspace autodetection
+- [generate_index](#generate_index) - disable generating a workspace index page
 - [members](#members) - list the workspace members
   - [members.slug](#membersslug) - the URL-safe slug to be used for this member
   - [members.path](#memberspath) - the path to this member's page source
@@ -66,6 +68,21 @@ workspace's members, as well as some quick info and metadata.
 
 Set the overarching workspace name. This is optional, and will fall back to "My Oranda Workspace" if not set (not very
 intuitive, I know).
+
+### auto
+
+> Added in version 0.3.0.
+
+Enables workspace autodetection if set to `true`. This will cause oranda to attempt to find any Cargo or NPM workspaces
+under the current directory, and to attempt to build all of its members (all members must therefore have at least a
+readme file). Members manually listed under the `members` key override these automatically detected workspace members.
+
+### generate_index
+
+> Added in version 0.3.0.
+
+If set to `false`, does not generate a workspace index page that links between all workspace members. Use this if you
+just want to use oranda's workspace functionality to build multiple unrelated sites in one go.
 
 ### members
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -36,7 +36,7 @@ impl Build {
         if let Some(config) = Site::get_workspace_config()? {
             let sites = Site::build_multi(&config)?;
             // FIXME: Let the user turn this off
-            if true {
+            if config.workspace.generate_index {
                 tracing::info!("Building workspace index page...");
                 let mut member_data = Vec::new();
                 for site in &sites {

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -9,6 +9,8 @@ use std::path::PathBuf;
 pub struct WorkspaceLayer {
     /// The top-level name to be used in the index page
     pub name: Option<String>,
+    /// Whether to generate an index page linking workspace members together
+    pub generate_index: Option<bool>,
     /// A list of workspace members
     pub members: Option<Vec<WorkspaceMember>>,
     /// Whether to enable workspace autodetection
@@ -27,6 +29,7 @@ pub struct WorkspaceMember {
 #[derive(Debug, Serialize, Clone)]
 pub struct WorkspaceConfig {
     pub name: Option<String>,
+    pub generate_index: bool,
     pub members: Vec<WorkspaceMember>,
     pub auto: bool,
 }
@@ -35,6 +38,7 @@ impl Default for WorkspaceConfig {
     fn default() -> Self {
         Self {
             name: Some("My Oranda Config".to_string()),
+            generate_index: true,
             members: Vec::new(),
             auto: false,
         }
@@ -47,9 +51,11 @@ impl ApplyLayer for WorkspaceConfig {
         let WorkspaceLayer {
             name,
             members,
+            generate_index,
             auto,
         } = layer;
         self.name.apply_opt(name);
+        self.generate_index.apply_val(generate_index);
         self.members.apply_val(members);
         self.auto.apply_val(auto);
     }


### PR DESCRIPTION
Closes #534, the option is called `generate_index`, open to naming changes :)