### PR TITLE
Allow more repos

### DIFF
--- a/tests/build/mod.rs
+++ b/tests/build/mod.rs
@@ -25,6 +25,15 @@ fn it_adds_additional_css() {
         .contents
         .contains(r#"<link rel="stylesheet" href="/custom.css" />"#));
 }
+#[test]
+fn it_can_point_to_custom_repository() {
+    let _guard = TEST_RUNTIME.enter();
+    let (_t, temp_dir) = temp_build_dir();
+    let mut config = oranda_config::cargo_dist(temp_dir);
+    config.project.repository = Some("https://github.com/axodotdev/privaterepo".into());
+    config.components.artifacts.as_mut().unwrap().auto = true;
+    oranda::site::Site::build_single(&config, None).unwrap();
+}
 
 #[test]
 fn it_renders_changelog_with_no_cargo_dist() {


### PR DESCRIPTION
Fixes #443. The repository's will now be ignored if we can't read it, and render will continue to work.

I'm not sure this is the right way to handle this case - When the user has indicated they want releases to be automatically discovered (at least, not `auto: false` :)) and we can't reach the repo, it's quite likely somethings misconfigured and they'd want alarms to start sounding so they can fix it.

Is there a way we could signal a soft error? It's something that should be urgently addressed (compared to warnings) but we can limp on from for now.