### PR TITLE
fix: don't generate broken link on changelog page

### DIFF
--- a/templates/includes/changelog_release.html.j2
+++ b/templates/includes/changelog_release.html.j2
@@ -1,5 +1,5 @@
 <section class="release {% if release.is_prerelease %}pre-release {% if not is_page %}hidden{% endif %}{% endif %}">
-    <h2 class="{% if is_page %}hidden{% endif %}" id="tag-{{ release.version_tag }}">
+    {% if not is_page %}<h2 id="tag-{{ release.version_tag }}">
         <a href="{{ release.version_tag }}/">
             {% if release.name %}
                 {{ release.name }}
@@ -7,7 +7,7 @@
                 {{ release.version_tag }}
             {% endif %}
         </a>
-    </h2>
+    </h2>{% endif %}
     <div class="release-info">
         <span class="flex items-center gap-2">
             {% include "icons/tag.html" %}


### PR DESCRIPTION
A leftover from `axohtml`, this would generate hidden header elements on single changelog pages that would otherwise show on the changelog index page. Because we have templates now, we can just not render that part in the case where it's not required.