### PR TITLE
feat: handle git+https urls

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -62,6 +62,10 @@ pub enum OrandaError {
         details: axoasset::AxoassetError,
     },
 
+    #[error("Your repository URL {url} couldn't be parsed.")]
+    #[diagnostic(help("oranda only supports URLs you can also use with Git."))]
+    UnknownRepoStyle { url: String },
+
     #[error("Could not find any releases from {repo_owner}/{repo_name} with a cargo-dist compatible `dist-manifest.json`.")]
     NoCargoDistReleasesFound {
         repo_owner: String,

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -95,18 +95,29 @@ impl Site {
         Self::print_plan(config);
 
         if needs_context {
-            let mut context = config.project.repository.as_ref().and_then(|repo_url| {
-                Context::new_github(
-                    repo_url,
-                    &config.project,
-                    config.components.artifacts.as_ref(),
-                ).ok().or_else(|| {
-                    tracing::warn!("Could not identify releases available from {}. note: only GitHub is currently supported", repo_url);
-                    None
+            let mut context = config
+                .project
+                .repository
+                .as_ref()
+                .and_then(|repo_url| {
+                    match Context::new_github(
+                        repo_url,
+                        &config.project,
+                        config.components.artifacts.as_ref(),
+                    ) {
+                        Ok(c) => Some(c),
+                        Err(e) => {
+                            // We don't want to hard error here, as we can most likely keep on going even
+                            // without a well-formed context.
+                            eprintln!("{:?}", miette::Report::new(e));
+                            None
+                        }
+                    }
                 })
-            }).map(Ok).unwrap_or_else(|| {
-                Context::new_current(&config.project, config.components.artifacts.as_ref())
-            })?;
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    Context::new_current(&config.project, config.components.artifacts.as_ref())
+                })?;
             if config.components.artifacts_enabled() {
                 if let Some(latest) = context.latest_mut() {
                     // Give especially nice treatment to the latest release and make


### PR DESCRIPTION
Also handles any errors happening inside of GitHub context creation more gracefully, printing them out instead of overwriting them with an arbitrary warning if any error happened at all.

Closes #531.