### PR TITLE
Docs: update web.yml

### DIFF
--- a/docs/src/hosting.md
+++ b/docs/src/hosting.md
@@ -86,7 +86,7 @@ jobs:
       # This will write all output to ./public/ (including copying mdbook's output to there)
       - name: Install and run oranda
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.1.0-prerelease.5/oranda-installer.sh | sh
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/latest/download/oranda-installer.sh | sh
           oranda build
 
       # Deploy to our gh-pages branch (making it if it doesn't exist)


### PR DESCRIPTION
The sample `web.yml` used for deploying points to a prerelease version of oranda; it should probably be using the latest instead. I also updated oranda's own `web.yml` to use the latest release.