### PR TITLE
Refactor dark theme + extras

### DIFF
--- a/oranda-css/css/base.css
+++ b/oranda-css/css/base.css
@@ -21,13 +21,8 @@ html {
 }
 
 body {
-  background-color: var(--light-color);
-  color: var(--dark-color);
-}
-
-.dark body {
-  background-color: var(--dark-color);
-  color: var(--light-color);
+  background-color: var(--bg-color);
+  color: var(--fg-color);
 }
 
 /* TEXT */
@@ -101,11 +96,7 @@ table td > code {
 
 table tbody tr {
   @apply border-t;
-  border-color: var(--dark-color);
-}
-
-.dark table tbody tr {
-  border-color: var(--light-color);
+  border-color: var(--fg-color);
 }
 
 div.table {
@@ -114,20 +105,12 @@ div.table {
 
 div.table .th {
   @apply text-left uppercase font-bold border-t text-lg p-4;
-  border-color: var(--dark-color);
-}
-
-.dark div.table .th {
-  border-color: var(--light-color);
+  border-color: var(--fg-color);
 }
 
 div.table span:not(.th) {
   @apply text-sm font-mono border-t p-4;
-  border-color: var(--dark-color);
-}
-
-.dark div.table span:not(.th) {
-  border-color: var(--light-color);
+  border-color: var(--fg-color);
 }
 
 /* LISTS */

--- a/oranda-css/css/buttons.css
+++ b/oranda-css/css/buttons.css
@@ -5,33 +5,24 @@
 /* A mono-color button */
 .button.primary {
   @apply border-transparent;
-  color: var(--light-color);
-  background-color: var(--dark-color);
-}
-
-.dark .button.primary {
-  color: var(--dark-color);
-  background-color: var(--light-color);
+  color: var(--fg-color);
+  background-color: var(--bg-color);
 }
 
 /* A duo-color button that changes when you hover over it. */
 .button.secondary {
-  color: var(--dark-color);
-  background-color: var(--light-color);
-  border-color: var(--dark-color);
+  color: var(--fg-color);
+  background-color: var(--bg-color);
+  border-color: var(--fg-color);
 }
 
 .button.secondary:hover {
-  color: var(--light-color);
-  background-color: var(--dark-color);
-  border-color: var(--light-color);
+  color: var(--bg-color);
+  background-color: var(--fg-color);
+  border-color: var(--bg-color);
 }
 
 select {
-  color: var(--dark-color);
-  background-color: var(--light-color);
-}
-.dark select {
-  color: var(--light-color);
-  background-color: var(--dark-color);
+  color: var(--fg-color);
+  background-color: var(--bg-color);
 }

--- a/oranda-css/css/components.css
+++ b/oranda-css/css/components.css
@@ -2,13 +2,8 @@
 
 footer {
   @apply flex w-full justify-between px-4 py-2 text-xs items-center shrink grow-0;
-  background-color: var(--dark-color);
-  color: var(--light-color);
-}
-
-.dark footer {
-  color: var(--dark-color);
-  background-color: var(--light-color);
+  background-color: var(--fg-color);
+  color: var(--bg-color);
 }
 
 /* NAV */
@@ -29,13 +24,8 @@ footer {
 
 .repo_banner {
   @apply py-1.5;
-  color: var(--light-color);
-  background-color: var(--dark-color);
-}
-
-.dark .repo_banner {
-  color: var(--dark-color);
-  background-color: var(--light-color);
+  color: var(--bg-color);
+  background-color: var(--fg-color);
 }
 
 .repo_banner > a {
@@ -62,15 +52,9 @@ footer {
 
 .funding-list li a:hover button {
   @apply text-slate-100 bg-axo-orange-dark border-axo-orange-dark;
-  color: var(--light-color);
-  background-color: var(--dark-color);
-  border-color: var(--light-color);
-}
-
-.dark .funding-list li a:hover button {
-  color: var(--dark-color);
-  background-color: var(--light-color);
-  border-color: var(--dark-color);
+  color: var(--bg-color);
+  background-color: var(--fg-color);
+  border-color: var(--bg-color);
 }
 
 .funding-list .button {

--- a/oranda-css/css/pages/artifacts.css
+++ b/oranda-css/css/pages/artifacts.css
@@ -12,21 +12,17 @@
 
 .artifacts {
   @apply sm:flex items-center flex-col mb-8 p-0 hidden;
-  color: var(--light-highlight-fg-color);
-  background-color: var(--light-highlight-bg-color);
+  color: var(--highlight-fg-color);
+  background-color: var(--highlight-bg-color);
 }
 
 .artifacts-table {
   @apply block max-w-full overflow-auto;
 }
 
-.dark .artifacts {
-  color: var(--dark-highlight-fg-color);
-  background-color: var(--dark-highlight-bg-color);
-}
-
 ul.tabs {
   @apply flex border-b-2;
+  border-color: var(--highlight-fg-color);
 }
 
 ul.tabs li {
@@ -34,13 +30,8 @@ ul.tabs li {
 }
 
 ul.tabs li.selected {
-  color: var(--light-highlight-bg-color);
-  background-color: var(--light-highlight-fg-color);
-}
-
-.dark ul.tabs li.selected {
-  color: var(--dark-highlight-bg-color);
-  background-color: var(--dark-highlight-fg-color);
+  color: var(--highlight-bg-color);
+  background-color: var(--highlight-fg-color);
 }
 
 .install-content {

--- a/oranda-css/css/pages/changelog.css
+++ b/oranda-css/css/pages/changelog.css
@@ -37,11 +37,7 @@
 }
 
 .release > h2 a {
-  color: var(--dark-color);
-}
-
-.dark .release > h2 a {
-  color: var(--light-color);
+  color: var(--fg-color);
 }
 
 .releases-list {
@@ -49,17 +45,13 @@
 }
 
 .releases-wrapper {
-  @apply grid gap-12 relative items-start mt-12;
-  grid-template-columns: 160px 1fr;
+  @apply grid gap-12 relative mt-12;
+  grid-template-columns: 160px minmax(0, 1fr);
 }
 
 .releases-nav ul {
   @apply list-none m-0 flex flex-col gap-2 border-l-4 pl-4;
-  border-color: var(--dark-color);
-}
-
-.dark .releases-nav ul {
-  border-color: var(--light-color);
+  border-color: var(--fg-color);
 }
 
 .releases-nav ul li {
@@ -69,20 +61,12 @@
 .releases-nav ul li:before {
   content: "";
   @apply h-1 w-4 block absolute top-1/2 -left-5 -translate-y-1/2;
-  background-color: var(--dark-color);
-}
-
-.dark .releases-nav ul li:before {
-  background-color: var(--light-color);
+  background-color: var(--fg-color);
 }
 
 .releases-nav ul li a {
   @apply decoration-transparent underline-offset-2 hover:underline;
-  color: var(--dark-color);
-}
-
-.dark .releases-nav ul li a {
-  color: var(--light-color);
+  color: var(--fg-color);
 }
 
 .release-info {
@@ -95,7 +79,7 @@
 
 .prereleases-toggle input {
   @apply h-5 w-5 rounded;
-  color: var(--dark-color);
+  color: var(--fg-color);
 }
 
 .prereleases-toggle label {

--- a/oranda-css/css/pages/workspace_index.css
+++ b/oranda-css/css/pages/workspace_index.css
@@ -4,7 +4,7 @@ ul.index-grid {
 
 .index-grid li {
     @apply ml-0 border rounded flex flex-col justify-between;
-    border-color: var(--light-color);
+    border-color: var(--bg-color);
     box-shadow: 0px 0px 0px 8px rgba(0, 0, 0, 0.3);
 }
 

--- a/oranda-css/css/themes/axo.css
+++ b/oranda-css/css/themes/axo.css
@@ -7,12 +7,13 @@ html.axo {
     --axo-pink-color: #FF75C3;
 
     /* Base Oranda theme variables */
-    --dark-color: #141414;
-    --link-color: var(--axo-pink-color);
-    --light-highlight-bg-color: var(--light-color);
-    --light-highlight-fg-color: var(--dark-color);
-    --dark-highlight-bg-color: var(--dark-color);
-    --dark-highlight-fg-color: var(--light-color);
+    --light-fg-color: #141414;
+    --light-link-color: var(--axo-pink-color);
+    --dark-link-color: var(--axo-pink-color);
+    --light-highlight-bg-color: var(--light-bg-color);
+    --light-highlight-fg-color: var(--light-fg-color);
+    --dark-highlight-bg-color: var(--light-fg-color);
+    --dark-highlight-fg-color: var(--light-bg-color);
     --font-face: "Comfortaa", sans-serif;
 }
 

--- a/oranda-css/css/variables.css
+++ b/oranda-css/css/variables.css
@@ -1,10 +1,31 @@
 :root {
-    --dark-color: #141414;
-    --light-color: #ffffff;
-    --link-color: #0284c7;
+    /* Base colors for text and background */
+    --dark-fg-color: #ffffff;
+    --light-fg-color: #141414;
+    --light-bg-color: var(--dark-fg-color);
+    --dark-bg-color: var(--light-fg-color);
+    --fg-color: var(--light-fg-color);
+    --bg-color: var(--light-bg-color);
+
+    /* Link colors */
+    --light-link-color: #0284c7;
+    --dark-link-color: #8BB9FE;
+    --link-color: var(--light-link-color);
+
+    /* Emphasis colors for text and background */
     --light-highlight-bg-color: #ededed;
     --light-highlight-fg-color: #595959;
     --dark-highlight-bg-color: #27272a;
     --dark-highlight-fg-color: #ededed;
+    --highlight-fg-color: var(--light-highlight-fg-color);
+    --highlight-bg-color: var(--light-highlight-bg-color);
     --font-face: "Fira Sans", sans-serif;
+}
+
+:root.dark {
+    --fg-color: var(--dark-fg-color);
+    --bg-color: var(--dark-bg-color);
+    --link-color: var(--dark-link-color);
+    --highlight-fg-color: var(--dark-highlight-fg-color);
+    --highlight-bg-color: var(--dark-highlight-bg-color);
 }

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -64,6 +64,10 @@ impl Site {
         member_data: &Vec<WorkspaceData>,
     ) -> Result<()> {
         let templates = Templates::new_for_workspace_index(workspace_config)?;
+        css::place_css(
+            &workspace_config.build.dist_dir,
+            &workspace_config.styles.oranda_css_version,
+        )?;
         let context = WorkspaceIndexContext::new(member_data, workspace_config)?;
         let page = Page::new_from_template(
             "index.html",


### PR DESCRIPTION
Closes #390.

- Simplifies our handling of dark mode CSS by inverting variables
- Writes CSS for the workspace index page (unrelated bug)
- Fixes a nasty bug where changelog content would overflow if the content was too wide. Before and after:

![CleanShot 2023-08-03 at 15 33 15@2x](https://github.com/axodotdev/oranda/assets/6445316/156040a3-cef7-4151-a82f-2a304203b245)

![CleanShot 2023-08-03 at 15 33 33@2x](https://github.com/axodotdev/oranda/assets/6445316/3f0be052-4703-4937-b204-6da01b16bbcf)
