### PR TITLE
Gallery demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v1
       - name: Run cargo test
         run: |
           cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1435,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "insta"
+version = "1.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0770b0a3d4c70567f0d58331f3088b0e4c4f56c9b8d764efe654b4a5d46de3a"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "regex",
+ "similar",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1971,8 +1991,10 @@ dependencies = [
  "console",
  "fs_extra",
  "futures-util",
+ "glob",
  "include_dir",
  "indexmap 1.9.3",
+ "insta",
  "lazy_static",
  "mdbook",
  "miette",
@@ -2784,6 +2806,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ oranda-generate-css = { version = "0.3.0-prerelease.4", path = "generate-css" }
 [dev-dependencies]
 assert_cmd = "2"
 assert_fs = "1.0.7"
+insta = { version = "1.31.0", features = ["filters"] }
+glob = "0.3.1"
 
 [build-dependencies]
 oranda-generate-css = { version = "0.3.0-prerelease.4", path = "generate-css" }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use oranda_generate_css::DEFAULT_CSS_OUTPUT_DIR;
+use oranda_generate_css::default_css_output_dir;
 
 fn main() {
     // Build the CSS on-demand if we're running a release-ish build here (as determined by Cargo)
@@ -10,6 +10,6 @@ fn main() {
             .build()
             .expect("Initializing tokio runtime failed");
         let _guard = runtime.enter();
-        oranda_generate_css::build_css(DEFAULT_CSS_OUTPUT_DIR).unwrap();
+        oranda_generate_css::build_css(&default_css_output_dir()).unwrap();
     }
 }

--- a/src/commands/print.rs
+++ b/src/commands/print.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use oranda::errors::*;
-use oranda_generate_css::DEFAULT_CSS_OUTPUT_DIR;
+use oranda_generate_css::default_css_output_dir;
 
 #[derive(Debug, Parser)]
 pub struct ConfigSchema {}
@@ -20,8 +20,9 @@ pub struct GenerateCss {}
 
 impl GenerateCss {
     pub fn run(&self) -> Result<()> {
-        oranda_generate_css::build_css(DEFAULT_CSS_OUTPUT_DIR)?;
-        tracing::info!("CSS placed in {DEFAULT_CSS_OUTPUT_DIR}/oranda.css");
+        let out_dir = default_css_output_dir();
+        oranda_generate_css::build_css(&out_dir)?;
+        tracing::info!("CSS placed in {out_dir}/oranda.css");
         Ok(())
     }
 }

--- a/src/config/builds.rs
+++ b/src/config/builds.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{ApplyLayer, ApplyOptExt, ApplyValExt};
 
@@ -22,7 +22,7 @@ pub struct BuildConfig {
     /// We use IndexMap to respect the order the user provided.
     pub additional_pages: IndexMap<String, String>,
 }
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 /// Information about how the pages of your site should be built
 pub struct BuildLayer {

--- a/src/config/components/artifacts/mod.rs
+++ b/src/config/components/artifacts/mod.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{ApplyLayer, ApplyValExt};
 
@@ -43,7 +43,7 @@ pub struct ArtifactsConfig {
 }
 
 /// Setting for downloadable artifacts, installers, and package-managers
-#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ArtifactsLayer {
     /// Whether to enable auto-detection of artifacts/installers in your Github Releases

--- a/src/config/components/artifacts/package_managers.rs
+++ b/src/config/components/artifacts/package_managers.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{ApplyLayer, ApplyValExt};
 
@@ -11,7 +11,7 @@ pub struct PackageManagersConfig {
     pub additional: IndexMap<String, String>,
 }
 /// Package managers to display
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct PackageManagersLayer {
     /// Packages to display in both the install widget and install page

--- a/src/config/components/funding.rs
+++ b/src/config/components/funding.rs
@@ -1,6 +1,6 @@
 use camino::Utf8PathBuf;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::config::{ApplyLayer, ApplyOptExt};
@@ -15,7 +15,7 @@ pub struct FundingConfig {
     pub md_path: Option<String>,
 }
 /// Settings for displaying funding information on your page
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FundingLayer {
     /// A funding method to make larger/focused to encourage over all others

--- a/src/config/components/mdbooks.rs
+++ b/src/config/components/mdbooks.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 use crate::config::{ApplyLayer, ApplyOptExt, ApplyValExt};
@@ -17,7 +17,7 @@ pub struct MdBookConfig {
 }
 
 /// The config for building and embedding an mdbook on your site
-#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct MdBookLayer {
     /// Path to the mdbook (the directory containing book.toml)

--- a/src/config/components/mod.rs
+++ b/src/config/components/mod.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 mod artifacts;
 mod funding;
@@ -38,7 +38,7 @@ pub struct ComponentConfig {
     pub artifacts: Option<ArtifactsConfig>,
 }
 /// Extra components
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ComponentLayer {
     /// Whether to enable the changelog page

--- a/src/config/marketing/analytics.rs
+++ b/src/config/marketing/analytics.rs
@@ -1,12 +1,12 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::site::layout::javascript::analytics::{Fathom, Google, Plausible, Umami};
 
 /// Settings for Analytics
 ///
 /// Analytics providers are currently mututally exclusive -- you can pick at most one.
-#[derive(Debug, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum AnalyticsConfig {
     /// Use Google Analytics

--- a/src/config/marketing/mod.rs
+++ b/src/config/marketing/mod.rs
@@ -1,6 +1,6 @@
 pub use analytics::AnalyticsConfig;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 pub use social::{SocialConfig, SocialLayer};
 
 use super::ApplyLayer;
@@ -17,7 +17,7 @@ pub struct MarketingConfig {
     pub social: SocialConfig,
 }
 /// Settings for marketing/social/analytics
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct MarketingLayer {
     /// Settings for analytics

--- a/src/config/marketing/social.rs
+++ b/src/config/marketing/social.rs
@@ -11,7 +11,7 @@ pub struct SocialConfig {
     pub twitter_account: Option<String>,
 }
 // Settings for social media integrations
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SocialLayer {
     /// Image to show in link previews

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -81,7 +81,7 @@ use std::convert::identity;
 
 use camino::Utf8PathBuf;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::errors::*;
@@ -103,9 +103,8 @@ pub use components::{
     MdBookConfig, MdBookLayer, PackageManagersConfig, PackageManagersLayer,
 };
 pub use marketing::{AnalyticsConfig, MarketingConfig, MarketingLayer, SocialConfig, SocialLayer};
-pub use workspace::{WorkspaceConfig, WorkspaceLayer};
+pub use workspace::{WorkspaceConfig, WorkspaceLayer, WorkspaceMember};
 
-use crate::config::workspace::WorkspaceMember;
 pub use project::{ProjectConfig, ProjectLayer};
 pub use style::{StyleConfig, StyleLayer};
 
@@ -393,7 +392,7 @@ impl<T> ApplyOptExt for Option<T> {
 ///
 /// This allows us to have a simple yes/no version of a config while still
 /// allowing for a more advanced version to exist.
-#[derive(Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(untagged)]
 pub enum BoolOr<T> {
     /// They gave the simple bool

--- a/src/config/oranda_config.rs
+++ b/src/config/oranda_config.rs
@@ -1,14 +1,14 @@
 use axoasset::SourceFile;
 use camino::Utf8PathBuf;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::errors::*;
 
 use super::{BuildLayer, ComponentLayer, MarketingLayer, ProjectLayer, StyleLayer, WorkspaceLayer};
 
 /// Configuration for `oranda` (typically stored in oranda.json)
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct OrandaLayer {
     /// Info about the project/application you're making a site for

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::{ApplyLayer, ApplyOptExt, ApplyValExt};
 
@@ -31,7 +31,7 @@ pub struct ProjectConfig {
 ///
 /// All of these values should automatically be sourced from your Cargo.toml or package.json
 /// whenever possible. You should only need to set these if you want to override the value.
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ProjectLayer {
     /// Name of the project

--- a/src/config/style.rs
+++ b/src/config/style.rs
@@ -1,5 +1,5 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{ApplyLayer, ApplyOptExt};
 use crate::site::{markdown::SyntaxTheme, oranda_theme::OrandaTheme};
@@ -19,7 +19,7 @@ pub struct StyleConfig {
     pub favicon: Option<String>,
 }
 /// Settings for styling your page
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct StyleLayer {
     /// The builtin oranda theme to use for all your pages

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 /// Configuration regarding multi-project "workspaces".
 pub struct WorkspaceLayer {

--- a/src/site/artifacts/mod.rs
+++ b/src/site/artifacts/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use crate::config::Config;
 use crate::data::artifacts::{File, FileIdx, InstallMethod, InstallerIdx, TargetTriple};
@@ -14,10 +14,7 @@ use serde::Serialize;
 /// The inner Vec is a list of supported platforms (display name).
 type DownloadableFiles = Vec<(FileIdx, File, Vec<String>)>;
 /// A map from TargetTriples to Installers that support that platform
-///
-/// In theory this should be BTreeMap or IndexMap but something in the pipeline from here to
-/// jinja seems to be forcing a sorting so it's deterministic..? Can't find docs for this.
-type Platforms = HashMap<TargetTriple, Vec<InstallerIdx>>;
+type Platforms = BTreeMap<TargetTriple, Vec<InstallerIdx>>;
 #[derive(Serialize, Debug)]
 pub struct Platform {
     target: TargetTriple,
@@ -97,7 +94,7 @@ pub fn template_context(context: &Context, config: &Config) -> Result<Option<Art
 /// Only grab platforms that we can actually provide downloadable files for.
 pub fn filter_platforms(release: &Release) -> Platforms {
     // First try to select platforms with downloadable artifacts
-    let mut platforms = HashMap::new();
+    let mut platforms = BTreeMap::new();
     for (target, installer) in release.artifacts.installers_by_target().iter() {
         let has_valid_installer = installer.iter().any(|i| {
             let installer = release.artifacts.installer(i.to_owned());

--- a/src/site/layout/css.rs
+++ b/src/site/layout/css.rs
@@ -45,7 +45,7 @@ pub fn place_css(dist_dir: &str, release_tag: &str) -> Result<()> {
         // on the spot. This is useful if we're working on oranda-css locally.
         #[cfg(debug_assertions)]
         {
-            oranda_generate_css::build_css(dist_dir)?;
+            oranda_generate_css::build_css(Utf8Path::new(dist_dir))?;
         }
         // If not, we rely on the `build.rs` file to have pre-compiled the CSS for us.
         #[cfg(not(debug_assertions))]

--- a/src/site/layout/javascript/analytics.rs
+++ b/src/site/layout/javascript/analytics.rs
@@ -40,23 +40,23 @@ impl Analytics {
     }
 }
 
-#[derive(Debug, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct Google {
     pub tracking_id: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct Fathom {
     pub site: String,
 }
 
-#[derive(Debug, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct Plausible {
     pub domain: String,
     pub script_url: Option<String>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct Umami {
     pub website: String,
     pub script_url: String,

--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -12,7 +12,8 @@ use javascript::analytics::Analytics;
 
 #[derive(Serialize, Debug, Default)]
 pub struct LayoutContext {
-    theme: OrandaTheme,
+    /// Result of [`OrandaTheme::as_css_classes`][]
+    theme: &'static str,
     project_name: String,
     homepage: Option<String>,
     repository: Option<String>,
@@ -107,7 +108,7 @@ impl LayoutContext {
         let analytics = Analytics::new(&config.marketing.analytics);
 
         Ok(Self {
-            theme: config.styles.theme,
+            theme: config.styles.theme.as_css_classes(),
             project_name: config.project.name.clone(),
             homepage: config.project.homepage.clone(),
             repository: config.project.repository.clone(),
@@ -138,10 +139,24 @@ impl LayoutContext {
         )?;
         Ok(Self {
             project_name: workspace_config.workspace.name.clone().unwrap_or_default(),
-            theme: workspace_config.styles.theme,
+            theme: workspace_config.styles.theme.as_css_classes(),
             oranda_css_path: css_path,
             path_prefix: workspace_config.build.path_prefix.clone(),
             ..Default::default()
         })
+    }
+}
+
+impl OrandaTheme {
+    /// Gets the css classes this theme lowers to
+    pub fn as_css_classes(&self) -> &'static str {
+        match self {
+            OrandaTheme::Light => "light",
+            OrandaTheme::Dark => "dark",
+            OrandaTheme::AxoLight => "axo",
+            OrandaTheme::AxoDark => "dark axo",
+            OrandaTheme::Hacker => "hacker",
+            OrandaTheme::Cupcake => "cupcake",
+        }
     }
 }

--- a/src/site/markdown/syntax_highlight/syntax_themes.rs
+++ b/src/site/markdown/syntax_highlight/syntax_themes.rs
@@ -1,7 +1,9 @@
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, JsonSchema)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
+)]
 pub enum SyntaxTheme {
     AgilaClassicOceanicNext,
     AgilaCobalt,

--- a/src/site/oranda_theme.rs
+++ b/src/site/oranda_theme.rs
@@ -1,16 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// The serde definitions here define what CSS class these themes lower to
-///
-/// We're currently transitioning from a system where the light and dark
-/// variants of a theme were basically completely independent, to a system
-/// where we just use an extra "dark" class to modify the light theme
-/// as appropriate.
-///
-/// So in the fullness of time Light and Dark here should probably get
-/// serialized as like "default" and "dark default", just as AxoLight
-/// and AxoDark get serialized as "axo" and "dark axo".
+/// Themes for oranda's output
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema,
 )]
@@ -18,9 +9,9 @@ use serde::{Deserialize, Serialize};
 pub enum OrandaTheme {
     Light,
     Dark,
-    #[serde(alias = "axo_light", rename(serialize = "axo"))]
+    #[serde(alias = "axo_light")]
     AxoLight,
-    #[serde(alias = "axo_dark", rename(serialize = "dark axo"))]
+    #[serde(alias = "axo_dark")]
     AxoDark,
     Hacker,
     Cupcake,

--- a/templates/includes/artifacts_header.html.j2
+++ b/templates/includes/artifacts_header.html.j2
@@ -68,7 +68,7 @@
         <a href="{{ "artifacts/" | generate_link(layout.path_prefix) }}" class="backup-download primary">View all installation options</a>
         {% if simple_platforms %}
             {% if first_target and first_target != "all" %}
-                <div class="arch-select">Platform: {{ platform.display_name }}</div>
+                <div class="arch-select">Platform: {{ artifacts.platforms_with_downloads | first | attr("display_name") }}</div>
             {% endif %}
         {% else %}
             <div class="arch-select hidden">

--- a/tests/gallery/command.rs
+++ b/tests/gallery/command.rs
@@ -1,0 +1,127 @@
+use miette::{miette, Context, IntoDiagnostic};
+use std::process::Command;
+
+pub struct CommandInfo {
+    name: String,
+    cmd: String,
+    args: Vec<String>,
+    version: Option<String>,
+}
+
+impl CommandInfo {
+    /// Create a new command, checking that it works by running it with `--version`
+    pub fn new(name: &str, path: Option<&str>) -> Option<Self> {
+        let cmd = path.unwrap_or(name).to_owned();
+        let output = Command::new(&cmd).arg("--version").output().ok()?;
+
+        Some(CommandInfo {
+            name: name.to_owned(),
+            cmd,
+            args: vec![],
+            version: parse_version(output),
+        })
+    }
+
+    /// Create a new command, don't check that it works
+    #[allow(dead_code)]
+    pub fn new_unchecked(name: &str, path: Option<&str>) -> Self {
+        let cmd = path.unwrap_or(name).to_owned();
+
+        CommandInfo {
+            name: name.to_owned(),
+            cmd,
+            args: vec![],
+            version: None,
+        }
+    }
+
+    /// Create a new powershell command (for running things like powershell modules)
+    pub fn new_powershell_command(name: &str) -> Option<Self> {
+        let output = Command::new("powershell")
+            .arg("-Command")
+            .arg("Get-Command")
+            .arg(name)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        Some(CommandInfo {
+            name: name.to_owned(),
+            cmd: "powershell".to_owned(),
+            args: vec!["-Command".to_owned(), name.to_owned()],
+            version: parse_version(output),
+        })
+    }
+
+    /// Run with `.output` and check for errors/status
+    pub fn output_checked(
+        &self,
+        builder: impl FnOnce(&mut Command) -> &mut Command,
+    ) -> Result<std::process::Output, miette::Report> {
+        let mut command = Command::new(&self.cmd);
+        command.args(&self.args);
+        builder(&mut command);
+        let output = command
+            .output()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to run \"{}\"", pretty_cmd(&self.name, &command)))?;
+        if output.status.success() {
+            Ok(output)
+        } else {
+            let mut out = String::new();
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            out.push_str("\nstdout:\n");
+            out.push_str(&stdout);
+            out.push_str("\nstderr:\n");
+            out.push_str(&stderr);
+            Err(miette!("{out}")).wrap_err_with(|| {
+                format!(
+                    "\"{}\" failed ({})",
+                    pretty_cmd(&self.name, &command),
+                    output.status
+                )
+            })
+        }
+    }
+
+    /// Run with `.output` and only check for errors, DON'T check status
+    pub fn output(
+        &self,
+        builder: impl FnOnce(&mut Command) -> &mut Command,
+    ) -> Result<std::process::Output, miette::Report> {
+        let mut command = Command::new(&self.cmd);
+        command.args(&self.args);
+        builder(&mut command);
+        let output = command
+            .output()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to run \"{}\"", pretty_cmd(&self.name, &command)))?;
+        Ok(output)
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
+    }
+}
+
+/// Parse out the version from `--version` assuming the standard `app-name 0.1.0` format
+fn parse_version(output: std::process::Output) -> Option<String> {
+    let version_bytes = output.stdout;
+    let version_full = String::from_utf8(version_bytes).ok()?;
+    let version_line = version_full.lines().next()?;
+    let version_suffix = version_line.split_once(' ')?.1.trim().to_owned();
+    Some(version_suffix)
+}
+
+/// Pretty print a command invocation
+fn pretty_cmd(name: &str, cmd: &Command) -> String {
+    let mut out = String::new();
+    out.push_str(name);
+    for arg in cmd.get_args() {
+        out.push(' ');
+        out.push_str(&arg.to_string_lossy())
+    }
+    out
+}

--- a/tests/gallery/errors.rs
+++ b/tests/gallery/errors.rs
@@ -1,0 +1,1 @@
+pub type Result<T> = std::result::Result<T, miette::Report>;

--- a/tests/gallery/mod.rs
+++ b/tests/gallery/mod.rs
@@ -1,0 +1,29 @@
+#![allow(dead_code)]
+
+mod command;
+mod errors;
+mod oranda_impl;
+mod repo;
+
+pub use errors::*;
+pub use oranda_impl::*;
+
+/// Taken from cargo-insta to avoid copy-paste errors
+///
+/// Gets the ~name of the function running this macro
+#[macro_export]
+macro_rules! _function_name {
+    () => {{
+        fn f() {}
+        fn type_name_of_val<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let mut name = type_name_of_val(f).strip_suffix("::f").unwrap_or("");
+        while let Some(rest) = name.strip_suffix("::{{closure}}") {
+            name = rest;
+        }
+        name.split_once("::")
+            .map(|(_module, func)| func)
+            .unwrap_or(name)
+    }};
+}

--- a/tests/gallery/oranda_impl.rs
+++ b/tests/gallery/oranda_impl.rs
@@ -1,0 +1,363 @@
+use std::sync::Mutex;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use miette::IntoDiagnostic;
+use oranda::config::{OrandaLayer, WorkspaceLayer, WorkspaceMember};
+
+use super::command::CommandInfo;
+use super::errors::Result;
+use super::repo::{Repo, TestContext, TestContextLock, ToolsImpl};
+
+/// Set this to change the date that we clamp Github Releases data to
+/// (prevents new Github Releases from breaking our tests, can be increased
+/// manually to update )
+///
+/// (RFC 3339 entry on utctime.net)
+const DEFAULT_DATA_CLAMP: &str = "2023-08-08T20:56:30+00:00";
+/// Set this at runtime to override DEFAULT_DATA_CLAMP           
+const ENV_DATA_CLAMP: &str = "DEBUG_DATA_CLAMP_DATE";
+/// Set this at runtime to override STATIC_CARGO_DIST_BIN
+const ENV_RUNTIME_ORANDA_BIN: &str = "OVERRIDE_CARGO_BIN_EXE_oranda";
+/// oranda binary that was built with `cargo test`
+const STATIC_ORANDA_BIN: &str = env!("CARGO_BIN_EXE_oranda");
+/// root dir of oranda so we can set the tests/snapshots/ dir reliably
+const ROOT_DIR: &str = env!("CARGO_MANIFEST_DIR");
+static TOOLS: Mutex<Option<Tools>> = Mutex::new(None);
+
+/// axolotlsay 0.1.0 is a nice simple project with shell+powershell+npm installers in its release
+pub static AXOLOTLSAY: TestContextLock<Tools> = TestContextLock::new(
+    &TOOLS,
+    &Repo {
+        repo_owner: "oranda-gallery",
+        repo_name: "axolotlsay",
+        commit_ref: "4b9bfe65973726271699421cc58026e3fc341e32",
+        app_name: "axolotlsay",
+        subdir: None,
+        bins: &["axolotlsay"],
+    },
+);
+/// akaikatana-repack 0.2.0 has multiple bins!
+pub static AKAIKATANA_REPACK: TestContextLock<Tools> = TestContextLock::new(
+    &TOOLS,
+    &Repo {
+        repo_owner: "oranda-gallery",
+        repo_name: "akaikatana-repack",
+        commit_ref: "c9ab9a2c6fb9d50f91915b7f61a6e9a1a8bbd4ec",
+        app_name: "akaikatana-repack",
+        subdir: None,
+        bins: &["akextract", "akmetadata", "akrepack"],
+    },
+);
+
+/// a repo with cargo-dist, but no releases
+pub static EMPTY_TEST: TestContextLock<Tools> = TestContextLock::new(
+    &TOOLS,
+    &Repo {
+        repo_owner: "oranda-gallery",
+        repo_name: "oranda-empty-test",
+        commit_ref: "28b8e2462a3f7bfbe7ea75cdac2fc4eb7ebb27cd",
+        app_name: "oranda-empty-test",
+        subdir: None,
+        bins: &["oranda-empty-test"],
+    },
+);
+
+/// a repo to test artifact inference
+pub static INFERENCE_TEST: TestContextLock<Tools> = TestContextLock::new(
+    &TOOLS,
+    &Repo {
+        repo_owner: "oranda-gallery",
+        repo_name: "oranda-inference-test",
+        commit_ref: "ad34864371fbe503c889ce555e9eee500663b2b9",
+        app_name: "oranda-inference-test",
+        subdir: None,
+        bins: &["oranda-inference-test"],
+    },
+);
+
+/// it's oranda!
+pub static ORANDA: TestContextLock<Tools> = TestContextLock::new(
+    &TOOLS,
+    &Repo {
+        repo_owner: "oranda-gallery",
+        repo_name: "oranda",
+        commit_ref: "0bd132c59c34e791713ee158fe5839cf29fcb6af",
+        app_name: "oranda",
+        subdir: None,
+        bins: &["oranda"],
+    },
+);
+
+pub struct Tools {
+    pub git: CommandInfo,
+    pub oranda: CommandInfo,
+    pub temp_root: Utf8PathBuf,
+}
+
+impl Tools {
+    fn new() -> Self {
+        eprintln!("getting tools...");
+        let git = CommandInfo::new("git", None).expect("git isn't installed");
+
+        // If OVERRIDE_* is set, prefer that over the version that cargo built for us,
+        // this lets us test our shippable builds.
+        let oranda_path =
+            std::env::var(ENV_RUNTIME_ORANDA_BIN).unwrap_or_else(|_| STATIC_ORANDA_BIN.to_owned());
+        let oranda = CommandInfo::new("oranda", Some(&oranda_path)).expect("oranda isn't built!?");
+
+        // If a data clamp isn't set, set one ourselves
+        if std::env::var(ENV_DATA_CLAMP).is_err() {
+            std::env::set_var(ENV_DATA_CLAMP, DEFAULT_DATA_CLAMP);
+        }
+
+        // Setup the tempdir / oranda-workspace.json
+        const TARGET_TEMP_DIR: &str = env!("CARGO_TARGET_TMPDIR");
+        let this = Self {
+            git,
+            oranda,
+            temp_root: Utf8PathBuf::from(TARGET_TEMP_DIR),
+        };
+        this.init_temp_workspace_root();
+
+        this
+    }
+
+    fn init_temp_workspace_root(&self) {
+        let temp_root = self.temp_root();
+        let public = self.oranda_workspace_dist();
+        if public.exists() {
+            std::fs::remove_dir_all(public).expect("failed to delete temp workspace 'public' dir");
+        }
+        if !temp_root.exists() {
+            std::fs::create_dir_all(temp_root).expect("failed to create temp workspace dir");
+        }
+
+        let json = OrandaLayer {
+            project: None,
+            build: None,
+            marketing: None,
+            styles: None,
+            components: None,
+            workspace: Some(WorkspaceLayer {
+                name: Some("oranda gallery".to_owned()),
+                generate_index: Some(true),
+                members: Some(vec![]),
+                auto: Some(false),
+            }),
+            _schema: None,
+        };
+        self.save_oranda_workspace_json(&json)
+            .expect("failed to create oranda-workspace.json");
+    }
+
+    pub fn temp_root(&self) -> &Utf8Path {
+        &self.temp_root
+    }
+
+    pub fn oranda_workspace_json(&self) -> Utf8PathBuf {
+        self.temp_root().join("oranda-workspace.json")
+    }
+
+    pub fn oranda_workspace_dist(&self) -> Utf8PathBuf {
+        self.temp_root().join("public")
+    }
+
+    pub fn save_oranda_workspace_json(&self, val: &OrandaLayer) -> Result<()> {
+        let json_src = serde_json::to_string_pretty(val).into_diagnostic()?;
+        axoasset::LocalAsset::write_new(&json_src, self.oranda_workspace_json())?;
+        Ok(())
+    }
+
+    pub fn load_oranda_workspace_json(&self) -> Result<OrandaLayer> {
+        let json_src = axoasset::SourceFile::load_local(self.oranda_workspace_json())?;
+        let json = json_src.deserialize_json()?;
+        Ok(json)
+    }
+}
+
+impl ToolsImpl for Tools {
+    fn git(&self) -> &CommandInfo {
+        &self.git
+    }
+}
+impl Default for Tools {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct OrandaResult {
+    test_name: String,
+    public_dir: Option<Utf8PathBuf>,
+}
+
+impl<'a> TestContext<'a, Tools> {
+    /// Run `oranda build` with the JSON configuration that we provided which sets up our fake
+    /// workspace
+    pub fn oranda_build(&self, test_name: &str) -> Result<OrandaResult> {
+        eprintln!("running oranda build...");
+        self.tools.oranda.output_checked(|cmd| cmd.arg("build"))?;
+
+        self.load_oranda_results(test_name)
+    }
+
+    fn load_oranda_results(&self, test_name: &str) -> Result<OrandaResult> {
+        // read/analyze installers
+        eprintln!("loading results...");
+
+        // Patch ourselves into things properly
+        if test_name != "gal_workspace" {
+            let mut json = self.tools.load_oranda_workspace_json()?;
+            json.workspace
+                .as_mut()
+                .unwrap()
+                .members
+                .as_mut()
+                .unwrap()
+                .push(WorkspaceMember {
+                    slug: test_name.to_owned(),
+                    path: self.working_dir.as_std_path().to_owned(),
+                });
+            self.tools.save_oranda_workspace_json(&json)?;
+        }
+
+        let public_dir = self.working_dir.join("public");
+
+        Ok(OrandaResult {
+            test_name: test_name.to_owned(),
+            public_dir: public_dir.exists().then_some(public_dir),
+        })
+    }
+
+    pub fn load_oranda_json(&self) -> Result<oranda::config::OrandaLayer> {
+        eprintln!("loading oranda.json...");
+        let json_src = axoasset::SourceFile::load_local("oranda.json")?;
+        let json = json_src.deserialize_json()?;
+        Ok(json)
+    }
+    pub fn save_oranda_json(&self, json: oranda::config::OrandaLayer) -> Result<()> {
+        eprintln!("storing oranda.json...");
+        let json_src = serde_json::to_string_pretty(&json).into_diagnostic()?;
+        axoasset::LocalAsset::write_new(&json_src, "oranda.json")?;
+        Ok(())
+    }
+}
+
+impl OrandaResult {
+    pub fn check_all(&self) -> Result<()> {
+        // Now that all other checks have passed, it's safe to check snapshots
+        self.snapshot()?;
+
+        Ok(())
+    }
+
+    // Run cargo-insta on everything we care to snapshot
+    pub fn snapshot(&self) -> Result<()> {
+        eprintln!("snapshotting...");
+        // We make a single uber-snapshot to avoid the annoyances of having multiple snapshots in one test
+        let mut snapshots = String::new();
+
+        let Some(src_path) = &self.public_dir else {
+            return Ok(());
+        };
+        for path in glob::glob(&format!("{}/**/*.html", src_path)).unwrap() {
+            let path = path.unwrap();
+
+            let path = Utf8PathBuf::from_path_buf(path).unwrap();
+            // We don't want to test another tool's output, so we filter out mdbook files. This
+            // is kind of a FIXME, the way we do this is very brittle, we should really be disabling
+            // mdbook from running altogether.
+            if !&path.to_string().contains("book") {
+                let rel_path = pathdiff::diff_utf8_paths(&path, src_path).unwrap();
+                // Normalize Windows slashes to Unix slashes
+                let rel_path = rel_path.to_string().replace('\\', "/");
+                Self::append_snapshot_file(
+                    &mut snapshots,
+                    &format!("public/{}", rel_path),
+                    Some(path.as_path()),
+                )
+                .unwrap();
+            }
+        }
+
+        let test_name = &self.test_name;
+        snapshot_settings_with_oranda_css_filter().bind(|| {
+            insta::assert_snapshot!(format!("{test_name}-public"), &snapshots);
+        });
+        Ok(())
+    }
+
+    fn append_snapshot_file(
+        out: &mut String,
+        name: &str,
+        src_path: Option<&Utf8Path>,
+    ) -> Result<()> {
+        // `glob` guarantees this path exists
+        let src_path = src_path.unwrap();
+        let src = axoasset::LocalAsset::load_string(src_path)?;
+        Self::append_snapshot_string(out, name, &src)
+    }
+
+    fn append_snapshot_string(out: &mut String, name: &str, val: &str) -> Result<()> {
+        use std::fmt::Write;
+
+        writeln!(out, "================ {name} ================").unwrap();
+        writeln!(out, "{val}").unwrap();
+        Ok(())
+    }
+}
+
+pub fn snapshot_settings() -> insta::Settings {
+    let mut settings = insta::Settings::clone_current();
+    let snapshot_dir = Utf8Path::new(ROOT_DIR).join("tests").join("snapshots");
+    settings.set_snapshot_path(snapshot_dir);
+    settings.set_prepend_module_to_snapshot(false);
+    settings
+}
+
+pub fn snapshot_settings_with_version_filter() -> insta::Settings {
+    let mut settings = snapshot_settings();
+    settings.add_filter(
+        r"\d+\.\d+\.\d+(\-prerelease\d*)?(\.\d+)?",
+        "1.0.0-FAKEVERSION",
+    );
+    settings
+}
+
+pub fn snapshot_settings_with_oranda_css_filter() -> insta::Settings {
+    let mut settings = snapshot_settings();
+    settings.add_filter(
+        r"oranda(-v\d+\.\d+\.\d+(\-prerelease\d*)?(\.\d+)?)?.css",
+        "oranda.css",
+    );
+    settings
+}
+
+pub fn snapshot_settings_with_dist_manifest_filter() -> insta::Settings {
+    let mut settings = snapshot_settings_with_version_filter();
+    settings.add_filter(
+        r#""announcement_tag": .*"#,
+        r#""announcement_tag": "CENSORED","#,
+    );
+    settings.add_filter(
+        r#""announcement_title": .*"#,
+        r#""announcement_title": "CENSORED""#,
+    );
+    settings.add_filter(
+        r#""announcement_changelog": .*"#,
+        r#""announcement_changelog": "CENSORED""#,
+    );
+    settings.add_filter(
+        r#""announcement_github_body": .*"#,
+        r#""announcement_github_body": "CENSORED""#,
+    );
+    settings.add_filter(
+        r#""announcement_is_prerelease": .*"#,
+        r#""announcement_is_prerelease": "CENSORED""#,
+    );
+    settings.add_filter(
+        r#""cargo_version_line": .*"#,
+        r#""cargo_version_line": "CENSORED""#,
+    );
+    settings
+}

--- a/tests/gallery/repo.rs
+++ b/tests/gallery/repo.rs
@@ -1,0 +1,208 @@
+use std::sync::{Mutex, MutexGuard};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use miette::IntoDiagnostic;
+
+use super::command::CommandInfo;
+use super::errors::Result;
+
+/// A subdir of `target/` that cargo helpfully defines for us to scribble in during tests.
+/// We are 100% responsible for its contents.
+const TARGET_TEMP_DIR: &str = env!("CARGO_TARGET_TMPDIR");
+
+/// Top-level type that should be used to declare `statics` that define test repos
+pub struct TestContextLock<Tools: 'static> {
+    repo: &'static Repo,
+    tools: &'static Mutex<Option<Tools>>,
+    ctx: Mutex<Option<RawTestContext>>,
+}
+/// Inner state of a TestContext
+pub struct RawTestContext {
+    pub repo: &'static Repo,
+    pub repo_id: String,
+    pub repo_dir: Utf8PathBuf,
+    pub working_dir: Utf8PathBuf,
+}
+/// Context passed down to test runs
+pub struct TestContext<'a, Tools> {
+    raw_ctx: &'a RawTestContext,
+    pub tools: &'a Tools,
+}
+impl<'a, Tools> std::ops::Deref for TestContext<'a, Tools> {
+    type Target = RawTestContext;
+    fn deref(&self) -> &Self::Target {
+        self.raw_ctx
+    }
+}
+/// Info about a repo (assumed to be a github repo)
+pub struct Repo {
+    pub repo_owner: &'static str,
+    pub repo_name: &'static str,
+    /// Can be a commit SHA, tag, or branch
+    pub commit_ref: &'static str,
+    /// subdir where the oranda.json is
+    pub subdir: Option<&'static str>,
+    /// name of the application (crate)
+    pub app_name: &'static str,
+    /// names of binaries the application should have
+    pub bins: &'static [&'static str],
+}
+
+pub trait ToolsImpl: Default {
+    /// Get an implementation of `git`
+    fn git(&self) -> &CommandInfo;
+}
+
+impl<Tools> TestContextLock<Tools>
+where
+    Tools: ToolsImpl,
+{
+    /// Create a new test with the given tools/repo
+    ///
+    /// Note that you should only have one Tools instance in your test suite, as it serves as a global
+    /// lock for global mutable state like `set_current_dir`.
+    pub const fn new(tools: &'static Mutex<Option<Tools>>, repo: &'static Repo) -> Self {
+        Self {
+            repo,
+            tools,
+            ctx: Mutex::new(None),
+        }
+    }
+
+    /// Run a test on this repo
+    pub fn run_test(&self, test: impl FnOnce(&TestContext<Tools>) -> Result<()>) -> Result<()> {
+        self.run_test_inner(None, test)
+    }
+
+    /// Run a test on a variant of this repo, checked out into a dir with the given name (id).
+    ///
+    /// Normally tests are ~free to mess with the checkout since they run in serial, but this
+    /// is useful if you want multiple modifications of the checkout to exist at once
+    /// (e.g. if you're handing all of them to the gallery workspace).
+    pub fn run_test_with_id(
+        &self,
+        id: &str,
+        test: impl FnOnce(&TestContext<Tools>) -> Result<()>,
+    ) -> Result<()> {
+        self.run_test_inner(Some(id), test)
+    }
+
+    fn run_test_inner(
+        &self,
+        id: Option<&str>,
+        test: impl FnOnce(&TestContext<Tools>) -> Result<()>,
+    ) -> Result<()> {
+        let maybe_tools = self.tools.lock();
+        // Intentionally unwrapping here to poison the mutexes if we can't fetch
+        let tools_guard = Self::init_mutex(maybe_tools, || Tools::default());
+        let tools = tools_guard.as_ref().unwrap();
+
+        // If there's an explicit id, then we're trying to do a "variant" test that is independent
+        // from the main variant. If so, create a new temporary `Mutex<Option<RawTestContext>>>`
+        // so that we don't clobber the "true" variant. It's fine that the result won't be cached
+        // properly -- variants are likely to be one-offs so caching is pointless.
+        let raw_ctx_lock;
+        let maybe_repo = if id.is_some() {
+            raw_ctx_lock = Mutex::new(None);
+            raw_ctx_lock.lock()
+        } else {
+            self.ctx.lock()
+        };
+        let raw_ctx_guard = Self::init_mutex(maybe_repo, || self.init_context(id, tools).unwrap());
+        let raw_ctx = raw_ctx_guard.as_ref().unwrap();
+
+        let ctx = TestContext { raw_ctx, tools };
+        // Ensure we're in the right dir before running the test
+        std::env::set_current_dir(&ctx.working_dir).unwrap();
+
+        test(&ctx)
+    }
+
+    /// Create the RawTestContext for this Repo by git fetching it to a sufficient temp dir
+    fn init_context(&self, id: Option<&str>, tools: &Tools) -> Result<RawTestContext> {
+        let Repo {
+            repo_owner,
+            repo_name,
+            commit_ref,
+            subdir,
+            ..
+        } = self.repo;
+        let repo_url: String = format!("https://github.com/{repo_owner}/{repo_name}");
+        let repo_id = id
+            .map(|id| id.to_owned())
+            .unwrap_or_else(|| format!("{repo_owner}_{repo_name}_{commit_ref}"));
+        let repo_dir = Utf8Path::new(TARGET_TEMP_DIR).join(&repo_id);
+        let working_dir = if let Some(subdir) = subdir {
+            repo_dir.join(subdir)
+        } else {
+            repo_dir.clone()
+        };
+
+        // Clone the repo we're interested in and cd into it
+        Self::fetch_repo(tools.git(), &repo_dir, &repo_url, commit_ref)?;
+
+        // Run tests
+        let ctx = RawTestContext {
+            repo: self.repo,
+            repo_id,
+            repo_dir,
+            working_dir,
+        };
+        Ok(ctx)
+    }
+
+    /// Take a potentially-poisoned, potentially-unintializeed `MutexGuard<Option<T>>` and
+    /// handle the poison and initialization of it.
+    ///
+    /// It's fine for the mutex to be poisoned once the value is Some because none of the tests
+    /// are allowed to mutate the TestContext. But if it's poisoned while None that means we
+    /// encountered an error while setting up the TestContext and should just abort everything
+    /// instead of retrying over and over. (e.g. git fetch failed, finding tools failed, etc.)
+    fn init_mutex<T>(
+        maybe_guard: std::sync::LockResult<MutexGuard<'_, Option<T>>>,
+        init: impl FnOnce() -> T,
+    ) -> MutexGuard<'_, Option<T>> {
+        let mut guard = match maybe_guard {
+            Ok(guard) => guard,
+            Err(poison) => {
+                let guard = poison.into_inner();
+                if guard.is_none() {
+                    panic!("aborting all tests: failed test harness initialization");
+                }
+                guard
+            }
+        };
+
+        if guard.is_none() {
+            let ctx = init();
+            *guard = Some(ctx);
+        }
+        guard
+    }
+
+    /// Fetch/update a repo to the given commit_ref
+    fn fetch_repo(
+        git: &CommandInfo,
+        repo_dir: &Utf8Path,
+        repo_url: &str,
+        commit_ref: &str,
+    ) -> Result<()> {
+        if repo_dir.exists() {
+            eprintln!("repo already cloned, updating it...");
+            std::env::set_current_dir(repo_dir).into_diagnostic()?;
+            git.output_checked(|c| c.arg("remote").arg("set-url").arg("origin").arg(repo_url))?;
+            git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_ref))?;
+            git.output_checked(|c| c.arg("reset").arg("--hard").arg("FETCH_HEAD"))?;
+        } else {
+            eprintln!("fetching {repo_url}");
+            axoasset::LocalAsset::create_dir_all(repo_dir)?;
+            std::env::set_current_dir(repo_dir).into_diagnostic()?;
+            git.output_checked(|c| c.arg("init"))?;
+            git.output_checked(|c| c.arg("remote").arg("add").arg("origin").arg(repo_url))?;
+            git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_ref))?;
+            git.output_checked(|c| c.arg("reset").arg("--hard").arg("FETCH_HEAD"))?;
+        }
+
+        Ok(())
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,107 @@
+mod gallery;
+use std::{collections::BTreeSet, env::set_current_dir};
+
+use gallery::*;
+
+#[test]
+fn gal_axolotlsay() -> Result<()> {
+    let test_name = _function_name!();
+    AXOLOTLSAY.run_test(|ctx| {
+        let res = ctx.oranda_build(test_name)?;
+        res.check_all()?;
+        Ok(())
+    })
+}
+
+#[test]
+fn gal_akaikatana() -> Result<()> {
+    let test_name = _function_name!();
+    AKAIKATANA_REPACK.run_test(|ctx| {
+        let res = ctx.oranda_build(test_name)?;
+        res.check_all()?;
+        Ok(())
+    })
+}
+
+#[test]
+fn gal_oranda() -> Result<()> {
+    let test_name = _function_name!();
+    ORANDA.run_test(|ctx| {
+        let res = ctx.oranda_build(test_name)?;
+        res.check_all()?;
+        Ok(())
+    })
+}
+
+#[test]
+fn gal_oranda_empty() -> Result<()> {
+    let test_name = _function_name!();
+    EMPTY_TEST.run_test(|ctx| {
+        let res = ctx.oranda_build(test_name)?;
+        res.check_all()?;
+        Ok(())
+    })
+}
+
+#[test]
+fn gal_oranda_inference() -> Result<()> {
+    let test_name = _function_name!();
+    INFERENCE_TEST.run_test(|ctx| {
+        let res = ctx.oranda_build(test_name)?;
+        res.check_all()?;
+        Ok(())
+    })
+}
+
+#[test]
+fn gal_workspace() -> Result<()> {
+    let test_name = _function_name!();
+    let mut num_iters = 0;
+    let mut should_sleep = true;
+
+    loop {
+        // Bail out and sleep for a while if not all the other tests are written
+        AXOLOTLSAY.run_test(|ctx| {
+            num_iters += 1;
+            // Go to the root
+            set_current_dir(ctx.tools.temp_root()).unwrap();
+
+            // Load the oranda-workspace.json and check if all tests are done
+            let json = ctx.tools.load_oranda_workspace_json()?;
+            let members = json.workspace.as_ref().unwrap().members.as_ref().unwrap();
+            let members_set = members
+                .iter()
+                .map(|m| m.slug.clone())
+                .collect::<BTreeSet<String>>();
+            let required_set = vec![
+                "gal_axolotlsay".to_owned(),
+                "gal_akaikatana".to_owned(),
+                "gal_oranda".to_owned(),
+                "gal_oranda_inference".to_owned(),
+                "gal_oranda_empty".to_owned(),
+            ]
+            .into_iter()
+            .collect::<BTreeSet<String>>();
+
+            if !required_set.is_subset(&members_set) {
+                // Sleep
+                return Ok(());
+            }
+            should_sleep = false;
+
+            let _res = ctx.oranda_build(test_name)?;
+            // Currently not snapshotting because enormous, but maybe do index.html..?
+            Ok(())
+        })?;
+
+        if should_sleep {
+            if num_iters < 30 {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+            } else {
+                panic!("gal_workspace timed out waiting for other tests");
+            }
+        } else {
+            return Ok(());
+        }
+    }
+}

--- a/tests/snapshots/gal_akaikatana-public.snap
+++ b/tests/snapshots/gal_akaikatana-public.snap
@@ -1,0 +1,631 @@
+---
+source: tests/gallery/oranda_impl.rs
+expression: "&snapshots"
+---
+================ public/artifacts/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="axo">
+    <head>
+        <title>akaikatana-repack</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="akaikatana-repack" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/akaikatana-repack/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/mistydemeo/akaikatana-repack">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">akaikatana-repack</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/akaikatana-repack/">Home</a></li>
+
+            
+
+            
+                <li><a href="/akaikatana-repack/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <div class="package-managers-downloads">
+        
+            
+                
+                <div>
+                    <h3>powershell</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/akaikatana-repack/akaikatana-repack-installer.ps1.txt">Source</a>
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>shell</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/akaikatana-repack/akaikatana-repack-installer.sh.txt">Source</a>
+    
+</div>
+                </div>
+            
+        
+            
+        
+            
+        
+            
+        
+            
+        
+    </div>
+    <div>
+        <h3>Downloads</h3>
+        <table class="artifacts-table">
+            <tbody>
+                <tr>
+                    <th>File</th>
+                    <th>Platform</th>
+                    
+                </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz">akaikatana-repack-aarch64-apple-darwin.tar.xz</a></td>
+                        <td>
+                            
+                                
+                                    macOS Apple Silicon
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz">akaikatana-repack-x86_64-apple-darwin.tar.xz</a></td>
+                        <td>
+                            
+                                
+                                    macOS Intel
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-pc-windows-msvc.zip">akaikatana-repack-x86_64-pc-windows-msvc.zip</a></td>
+                        <td>
+                            
+                                
+                                    Windows x64
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz">akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz</a></td>
+                        <td>
+                            
+                                
+                                    Linux x64
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+            </tbody>
+        </table>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/mistydemeo/akaikatana-repack"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    akaikatana-repack, GPL-2.0-or-later
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+<script src="/akaikatana-repack/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="axo">
+    <head>
+        <title>akaikatana-repack</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="akaikatana-repack" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/akaikatana-repack/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/mistydemeo/akaikatana-repack">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">akaikatana-repack</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/akaikatana-repack/">Home</a></li>
+
+            
+
+            
+                <li><a href="/akaikatana-repack/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+
+    
+
+
+
+<div class="artifacts" data-tag="v0.2.0">
+    <div class="artifact-header target">
+        <h4>Install v0.2.0</h4>
+        
+            <div><small class="published-date">Published on Jun 30 2023 at 03:29 UTC</small></div>
+        
+
+        <ul class="arches">
+            
+                <li class="arch hidden" data-arch="aarch64-apple-darwin">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="aarch64-apple-darwin">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="2" data-triple="aarch64-apple-darwin">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="aarch64-apple-darwin" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/akaikatana-repack/akaikatana-repack-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="2" data-triple="aarch64-apple-darwin" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">akaikatana-repack-aarch64-apple-darwin.tar.xz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-apple-darwin">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="x86_64-apple-darwin">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="3" data-triple="x86_64-apple-darwin">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="x86_64-apple-darwin" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/akaikatana-repack/akaikatana-repack-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="3" data-triple="x86_64-apple-darwin" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">akaikatana-repack-x86_64-apple-darwin.tar.xz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-pc-windows-msvc">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="1" data-triple="x86_64-pc-windows-msvc">
+                                    powershell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="4" data-triple="x86_64-pc-windows-msvc">
+                                    zip
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="1" data-triple="x86_64-pc-windows-msvc" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/akaikatana-repack/akaikatana-repack-installer.ps1.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="4" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-pc-windows-msvc.zip">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">akaikatana-repack-x86_64-pc-windows-msvc.zip</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-unknown-linux-gnu">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="x86_64-unknown-linux-gnu">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="5" data-triple="x86_64-unknown-linux-gnu">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="x86_64-unknown-linux-gnu" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/akaikatana-repack/akaikatana-repack-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="5" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+        </ul>
+    </div>
+
+    
+        <div class="no-autodetect hidden">
+            <span class="no-autodetect-details">We weren't able to detect your OS.</span>
+        </div>
+        <noscript>
+            <a href="/akaikatana-repack/artifacts/">View all installation options</a>
+        </noscript>
+    
+    <div class="mac-switch hidden">This project doesn't offer Apple Silicon downloads, but you can run Intel macOS binaries via Rosetta 2.</div>
+
+    
+    
+    <div class="bottom-options ">
+        <a href="/akaikatana-repack/artifacts/" class="backup-download primary">View all installation options</a>
+        
+            <div class="arch-select hidden">
+                <select id="install-arch-select">
+                    <option disabled="true" selected="true" value=""></option>
+                    
+                        <option value="x86_64-unknown-linux-gnu">Linux x64</option>
+                    
+                        <option value="aarch64-apple-darwin">macOS Apple Silicon</option>
+                    
+                        <option value="x86_64-apple-darwin">macOS Intel</option>
+                    
+                        <option value="x86_64-pc-windows-msvc">Windows x64</option>
+                    
+                </select>
+            </div>
+        
+    </div>
+</div>
+
+<a href="/akaikatana-repack/artifacts/" class="button mobile-download primary">View all installation options</a>
+
+<h2>Akai Katana music repacker</h2>
+<p>This set of tools allows you to extract and replace the music from the <a href="https://store.steampowered.com/app/2076220/Akai_Katana_Shin/" rel="noopener noreferrer">Steam release of Akai Katana</a>. I was inspired to make it because I love the FM arranged soundtrack from the Nin2 Jump/Akai Katana CD, but there's no way to actually use it in game. If there won't be an official one, why not make my own?</p>
+<h3>Getting the tool</h3>
+<p>Prebuilt copies of the tool can be found in the <a href="https://github.com/mistydemeo/akaikatana-repack/releases" rel="noopener noreferrer">"releases" tab</a> in GitHub. You should be able to just download and run the ZIP file or tarball.</p>
+<h3>How to use</h3>
+<p>Akai Katana's music is in a file called <code>Stream.bin</code> within the game folder. To start, copy it into the folder with these tools.</p>
+<p>The <code>akextract</code> tool is used to extract the music from <code>Stream.bin</code>. After extracting, you'll have a set of 40 <code>.wav</code> files with all the music from all three versions of the soundtrack. The <code>tracklist.txt</code> file in the documents folder explains which file is which song.</p>
+<p>To replace songs with new ones, you'll need to reencode the new file in Microsoft's ADPCM format. Doing this requires Microsoft's commandline tool <code>AdpcmEncode.exe</code>. The game won't accept normal WAV files, and it won't accept ADPCM files made with any other tool (like FFmpeg).</p>
+<p>To let the music loop properly, you can use a tool such as <a href="https://www.wavosaur.com" rel="noopener noreferrer">Wavosaur</a>; instructions for editing loop points are <a href="https://www.wavosaur.com/quick-help/loop-points-edition.php" rel="noopener noreferrer">here</a>. <code>AdpcmEncode.exe</code> will use the loop points embedded into the uncompressed WAV files. If you're using the FM arrange from the Nin2 Jump/Akai Katana CD, I've included a set of loop points in the <code>loop_points.txt</code> file in the documents folder.</p>
+<p>Once you're done preparing your music, place your new ADPCM WAV files in a folder with any of the original music you're keeping. Your new folder should still have 40 WAV files with the same numbered names as the original ones. Once you're ready, you can run the <code>akrepack</code> tool to repackage your files into a new <code>Stream.bin</code>. For example, if your new soundtrack is in a folder called <code>in</code>, you would run <code>akrepack --input in</code>. This will produce a new file called <code>Stream.bin.repacked</code>. Just replace the file in Akai Katana's game folder with this new file, and you're ready to go.</p>
+<h3>Notes</h3>
+<p>Although my generated files have loop points in place, I've had some trouble getting the game to use them. If anyone figures out what's wrong and could lend a hand, I'd appreciate it!</p>
+<p>Shin mode features one extra stage, stage 5, and the music used for that stage is missing in the arcade soundtrack. When you play Shin with the original soundtrack, stage 5 will use the song from the 360 arranged soundtrack.</p>
+<h3>Building from source</h3>
+<p>These tools are written in Rust, and can be built using standard Rust tools. As long as you have the Rust compiler installed, you just need to run <code>cargo build</code>.</p>
+<h3>Contributing</h3>
+<p>Contributions are always welcome! Please open issues if you run into any issues, and pull requests are always a big help.</p>
+<h3>License</h3>
+<p>GPL 2.0 or later.</p>
+
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/mistydemeo/akaikatana-repack"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    akaikatana-repack, GPL-2.0-or-later
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+
+    <script src="/akaikatana-repack/artifacts.js"></script>
+
+
+    </body>
+</html>
+

--- a/tests/snapshots/gal_axolotlsay-public.snap
+++ b/tests/snapshots/gal_axolotlsay-public.snap
@@ -1,0 +1,1116 @@
+---
+source: tests/gallery/oranda_impl.rs
+expression: "&snapshots"
+---
+================ public/artifacts/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>axolotlsay</title>
+        
+        
+            <link rel="icon" href="/axolotlsay/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="💬 a CLI for learning to distribute CLIs in rust" />
+            <meta property="og:description" content="💬 a CLI for learning to distribute CLIs in rust" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="axolotlsay" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/axolotlsay/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/axolotlsay">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">axolotlsay</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/axolotlsay/">Home</a></li>
+
+            
+
+            
+                <li><a href="/axolotlsay/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/axolotlsay/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <div class="package-managers-downloads">
+        
+            
+                
+                <div>
+                    <h3>binstall</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo binstall axolotlsay</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo binstall axolotlsay">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>crates.io</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo install axolotlsay</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">locked</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">profile</span><span style="color:#89ddff;">=</span><span style="color:#82aaff;">dist</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo install axolotlsay --locked --profile=dist">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>npm</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npm install @axodotdev/axolotlsay@0.1.0</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npm install @axodotdev/axolotlsay@0.1.0">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>npx</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npx @axodotdev/axolotlsay</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npx @axodotdev/axolotlsay">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>powershell</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/axolotlsay/axolotlsay-installer.ps1.txt">Source</a>
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>shell</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/axolotlsay/axolotlsay-installer.sh.txt">Source</a>
+    
+</div>
+                </div>
+            
+        
+            
+        
+            
+        
+            
+        
+            
+        
+    </div>
+    <div>
+        <h3>Downloads</h3>
+        <table class="artifacts-table">
+            <tbody>
+                <tr>
+                    <th>File</th>
+                    <th>Platform</th>
+                    
+                </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz">axolotlsay-aarch64-apple-darwin.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    macOS Apple Silicon
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz">axolotlsay-x86_64-apple-darwin.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    macOS Intel
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz">axolotlsay-x86_64-pc-windows-msvc.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    Windows x64
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz">axolotlsay-x86_64-unknown-linux-gnu.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    Linux x64
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
+            </tbody>
+        </table>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/axolotlsay"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    axolotlsay, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+<script src="/axolotlsay/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/changelog/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>axolotlsay</title>
+        
+        
+            <link rel="icon" href="/axolotlsay/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="💬 a CLI for learning to distribute CLIs in rust" />
+            <meta property="og:description" content="💬 a CLI for learning to distribute CLIs in rust" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="axolotlsay" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/axolotlsay/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/axolotlsay">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">axolotlsay</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/axolotlsay/">Home</a></li>
+
+            
+
+            
+                <li><a href="/axolotlsay/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/axolotlsay/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Releases</h1>
+    <div class="releases-wrapper">
+        <nav class="releases-nav">
+            
+
+            <ul>
+                
+                     <li class="">
+                         <a href="v0.1.0/">v0.1.0</a>
+                     </li>
+                
+            </ul>
+        </nav>
+
+        <div class="releases-list">
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.1.0">
+        <a href="v0.1.0/">
+            
+                Version 0.1.0
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 24 2023 at 17:35 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <pre style="background-color:#263238;"><span style="color:#eeffff;">         +------------------------+
+</span><span style="color:#eeffff;">         | the initial release!!! |
+</span><span style="color:#eeffff;">         +------------------------+
+</span><span style="color:#eeffff;">        /
+</span><span style="color:#eeffff;">≽(◕ ᴗ ◕)≼
+</span></pre>
+
+
+    </div>
+</section>
+            
+        </div>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/axolotlsay"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    axolotlsay, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+<script src="/axolotlsay/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/changelog/v0.1.0/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>axolotlsay</title>
+        
+        
+            <link rel="icon" href="/axolotlsay/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="💬 a CLI for learning to distribute CLIs in rust" />
+            <meta property="og:description" content="💬 a CLI for learning to distribute CLIs in rust" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="axolotlsay" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/axolotlsay/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/axolotlsay">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">axolotlsay</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/axolotlsay/">Home</a></li>
+
+            
+
+            
+                <li><a href="/axolotlsay/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/axolotlsay/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 24 2023 at 17:35 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <pre style="background-color:#263238;"><span style="color:#eeffff;">         +------------------------+
+</span><span style="color:#eeffff;">         | the initial release!!! |
+</span><span style="color:#eeffff;">         +------------------------+
+</span><span style="color:#eeffff;">        /
+</span><span style="color:#eeffff;">≽(◕ ᴗ ◕)≼
+</span></pre>
+
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/axolotlsay"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    axolotlsay, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>axolotlsay</title>
+        
+        
+            <link rel="icon" href="/axolotlsay/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="💬 a CLI for learning to distribute CLIs in rust" />
+            <meta property="og:description" content="💬 a CLI for learning to distribute CLIs in rust" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="axolotlsay" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/axolotlsay/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/axolotlsay">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">axolotlsay</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/axolotlsay/">Home</a></li>
+
+            
+
+            
+                <li><a href="/axolotlsay/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/axolotlsay/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+
+    
+
+
+
+<div class="artifacts" data-tag="v0.1.0">
+    <div class="artifact-header target">
+        <h4>Install v0.1.0</h4>
+        
+            <div><small class="published-date">Published on May 24 2023 at 17:35 UTC</small></div>
+        
+
+        <ul class="arches">
+            
+                <li class="arch hidden" data-arch="aarch64-apple-darwin">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="aarch64-apple-darwin">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="aarch64-apple-darwin">
+                                    npx
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="3" data-triple="aarch64-apple-darwin">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="aarch64-apple-darwin" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/axolotlsay/axolotlsay-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="aarch64-apple-darwin" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npx @axodotdev/axolotlsay</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npx @axodotdev/axolotlsay">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="3" data-triple="aarch64-apple-darwin" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">axolotlsay-aarch64-apple-darwin.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-apple-darwin">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="x86_64-apple-darwin">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="x86_64-apple-darwin">
+                                    npx
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="4" data-triple="x86_64-apple-darwin">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="x86_64-apple-darwin" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/axolotlsay/axolotlsay-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="x86_64-apple-darwin" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npx @axodotdev/axolotlsay</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npx @axodotdev/axolotlsay">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="4" data-triple="x86_64-apple-darwin" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">axolotlsay-x86_64-apple-darwin.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-pc-windows-msvc">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="1" data-triple="x86_64-pc-windows-msvc">
+                                    powershell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="x86_64-pc-windows-msvc">
+                                    npx
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="5" data-triple="x86_64-pc-windows-msvc">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="1" data-triple="x86_64-pc-windows-msvc" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/axolotlsay/axolotlsay-installer.ps1.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npx @axodotdev/axolotlsay</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npx @axodotdev/axolotlsay">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="5" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">axolotlsay-x86_64-pc-windows-msvc.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-unknown-linux-gnu">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="x86_64-unknown-linux-gnu">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="x86_64-unknown-linux-gnu">
+                                    npx
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="6" data-triple="x86_64-unknown-linux-gnu">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="x86_64-unknown-linux-gnu" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/axolotlsay/axolotlsay-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npx @axodotdev/axolotlsay</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npx @axodotdev/axolotlsay">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="6" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">axolotlsay-x86_64-unknown-linux-gnu.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+        </ul>
+    </div>
+
+    
+        <div class="no-autodetect hidden">
+            <span class="no-autodetect-details">We weren't able to detect your OS.</span>
+        </div>
+        <noscript>
+            <a href="/axolotlsay/artifacts/">View all installation options</a>
+        </noscript>
+    
+    <div class="mac-switch hidden">This project doesn't offer Apple Silicon downloads, but you can run Intel macOS binaries via Rosetta 2.</div>
+
+    
+    
+    <div class="bottom-options ">
+        <a href="/axolotlsay/artifacts/" class="backup-download primary">View all installation options</a>
+        
+            <div class="arch-select hidden">
+                <select id="install-arch-select">
+                    <option disabled="true" selected="true" value=""></option>
+                    
+                        <option value="x86_64-unknown-linux-gnu">Linux x64</option>
+                    
+                        <option value="aarch64-apple-darwin">macOS Apple Silicon</option>
+                    
+                        <option value="x86_64-apple-darwin">macOS Intel</option>
+                    
+                        <option value="x86_64-pc-windows-msvc">Windows x64</option>
+                    
+                </select>
+            </div>
+        
+    </div>
+</div>
+
+<a href="/axolotlsay/artifacts/" class="button mobile-download primary">View all installation options</a>
+
+<h1>axolotlsay</h1>
+<blockquote>
+<p>💬 a CLI for learning to distribute CLIs in rust</p>
+</blockquote>
+<h2>Usage</h2>
+<pre style="background-color:#263238;"><span style="color:#89ddff;">&gt;</span><span style="color:#82aaff;"> axolotlsay </span><span style="color:#89ddff;">"</span><span style="color:#c3e88d;">hello world</span><span style="color:#89ddff;">"
+</span><span style="color:#eeffff;">
+</span><span style="color:#eeffff;">         </span><span style="color:#82aaff;">+-------------+
+</span><span style="color:#eeffff;">         </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">hello world </span><span style="color:#89ddff;">|
+</span><span style="color:#eeffff;">         </span><span style="color:#82aaff;">+-------------+
+</span><span style="color:#eeffff;">        </span><span style="color:#82aaff;">/
+</span><span style="color:#82aaff;">≽(◕ ᴗ ◕</span><span style="color:#eeffff;">)</span><span style="color:#82aaff;">≼
+</span></pre>
+
+<h2>License</h2>
+<p>Licensed under either of</p>
+<ul>
+<li>Apache License, Version 2.0, (<a href="LICENSE-APACHE" rel="noopener noreferrer">LICENSE-APACHE</a> or <a href="https://www.apache.org/licenses/LICENSE-2.0" rel="noopener noreferrer">apache.org/licenses/LICENSE-2.0</a>)</li>
+<li>MIT license (<a href="LICENSE-MIT" rel="noopener noreferrer">LICENSE-MIT</a> or <a href="https://opensource.org/licenses/MIT" rel="noopener noreferrer">opensource.org/licenses/MIT</a>)</li>
+</ul>
+<p>at your option.</p>
+
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/axolotlsay"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    axolotlsay, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+
+    <script src="/axolotlsay/artifacts.js"></script>
+
+
+    </body>
+</html>
+

--- a/tests/snapshots/gal_oranda-public.snap
+++ b/tests/snapshots/gal_oranda-public.snap
@@ -1,0 +1,6843 @@
+---
+source: tests/gallery/oranda_impl.rs
+expression: "&snapshots"
+---
+================ public/artifacts/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <div class="package-managers-downloads">
+        
+            
+                
+                <div>
+                    <h3>binstall</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo binstall oranda</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo binstall oranda">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>cargo</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo install oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">locked</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">profile</span><span style="color:#89ddff;">=</span><span style="color:#82aaff;">dist</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo install oranda --locked --profile=dist">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>nix flake</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">nix profile install github:axodotdev/oranda</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="nix profile install github:axodotdev/oranda">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>nix-env</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">nix-env</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">i</span><span style="color:#82aaff;"> oranda</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="nix-env -i oranda">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>npm</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npm install @axodotdev/oranda@0.2.0</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npm install @axodotdev/oranda@0.2.0">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>npm</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npm install @axodotdev/oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">save-dev</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npm install @axodotdev/oranda --save-dev">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>npx</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npx @axodotdev/oranda</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npx @axodotdev/oranda">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>powershell</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/oranda/oranda-installer.ps1.txt">Source</a>
+    
+</div>
+                </div>
+            
+        
+            
+                
+                <div>
+                    <h3>shell</h3>
+                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/oranda/oranda-installer.sh.txt">Source</a>
+    
+</div>
+                </div>
+            
+        
+            
+        
+            
+        
+            
+        
+            
+        
+    </div>
+    <div>
+        <h3>Downloads</h3>
+        <table class="artifacts-table">
+            <tbody>
+                <tr>
+                    <th>File</th>
+                    <th>Platform</th>
+                    
+                        <th>Checksum</th>
+                    
+                </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz">oranda-aarch64-apple-darwin.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    macOS Apple Silicon
+                                
+                            
+                        </td>
+                        
+                            
+                                
+                                <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz.sha256">checksum</a></td>
+                            
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz">oranda-x86_64-apple-darwin.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    macOS Intel
+                                
+                            
+                        </td>
+                        
+                            
+                                
+                                <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz.sha256">checksum</a></td>
+                            
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz">oranda-x86_64-pc-windows-msvc.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    Windows x64
+                                
+                            
+                        </td>
+                        
+                            
+                                
+                                <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz.sha256">checksum</a></td>
+                            
+                        
+                    </tr>
+                
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz">oranda-x86_64-unknown-linux-gnu.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    Linux x64
+                                
+                            
+                        </td>
+                        
+                            
+                                
+                                <td><a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz.sha256">checksum</a></td>
+                            
+                        
+                    </tr>
+                
+            </tbody>
+        </table>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+<script src="/oranda/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/changelog/css-v0.0.0/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.0</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Mar  8 2023 at 14:47 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/css-v0.0.1/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.1</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Mar 17 2023 at 12:45 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/css-v0.0.2/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.2</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Mar 21 2023 at 21:46 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/css-v0.0.3/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.3</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May  8 2023 at 23:08 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/css-v0.0.4/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.4</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.4
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May  9 2023 at 00:21 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/css-v0.0.5/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.5</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.5
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 12 2023 at 13:43 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/css-v0.0.6/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.6</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.6
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 19 2023 at 23:57 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/css-v0.0.7/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>css-v0.0.7</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.7
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 20 2023 at 14:51 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Releases</h1>
+    <div class="releases-wrapper">
+        <nav class="releases-nav">
+            
+                <div class="prereleases-toggle">
+                    <div class="flex h-6 items-center">
+                        <input type="checkbox" id="show-prereleases" />
+                    </div>
+                    <div class="ml-3">
+                        <label for="show-prereleases">Show prereleases</label>
+                    </div>
+                </div>
+            
+
+            <ul>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.3.0-prerelease.5/">v0.3.0-prerelease.5</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.3.0-prerelease.4/">v0.3.0-prerelease.4</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.3.0-prerelease.3/">v0.3.0-prerelease.3</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.3.0-prerelease.2/">v0.3.0-prerelease.2</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.3.0-prerelease.1/">v0.3.0-prerelease.1</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="v0.2.0/">v0.2.0</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.2.0-prerelease.1/">v0.2.0-prerelease.1</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="v0.1.1/">v0.1.1</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="v0.1.0/">v0.1.0</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.9/">v0.1.0-prerelease.9</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.8/">v0.1.0-prerelease.8</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.7/">v0.1.0-prerelease.7</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.7/">css-v0.0.7</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.6/">css-v0.0.6</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.6/">v0.1.0-prerelease.6</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.5/">css-v0.0.5</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.5/">v0.1.0-prerelease.5</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.4/">v0.1.0-prerelease.4</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.3/">v0.1.0-prerelease.3</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.2/">v0.1.0-prerelease.2</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.1.0-prerelease.1/">v0.1.0-prerelease.1</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="v0.0.3/">v0.0.3</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.4/">css-v0.0.4</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.3/">css-v0.0.3</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="v0.0.2/">v0.0.2</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.2/">css-v0.0.2</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.1/">css-v0.0.1</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="css-v0.0.0/">css-v0.0.0</a>
+                     </li>
+                
+                     <li class="">
+                         <a href="v0.0.1/">v0.0.1</a>
+                     </li>
+                
+                     <li class="pre-release hidden">
+                         <a href="v0.0.1-prerelease2/">v0.0.1-prerelease2</a>
+                     </li>
+                
+            </ul>
+        </nav>
+
+        <div class="releases-list">
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.3.0-prerelease.5">
+        <a href="v0.3.0-prerelease.5/">
+            
+                Version 0.3.0-prerelease.5
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.5
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  3 2023 at 17:45 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/many PRs, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+<li>
+<p><strong>Inlining CSS</strong> - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/565" rel="noopener noreferrer">pr565</a>, <a href="https://github.com/axodotdev/oranda/pull/566" rel="noopener noreferrer">pr566</a>, <a href="https://github.com/axodotdev/oranda/issues/554" rel="noopener noreferrer">i554</a></p>
+<p>oranda now uses a CSS version that's included in the binary it's shipped with! This means no more HTTP requests to GitHub
+to fetch a CSS version over and over. As a bonus, we removed the internal dependency on a Node.js toolchain to build
+the CSS in development, which should make hacking on oranda and its themes a lot easier!</p>
+</li>
+<li>
+<p><strong>Basic CSS caching - <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/pull/551" rel="noopener noreferrer">pr551</a></strong></p>
+<p>In line with workspace support, oranda will now attempt to keep already downloaded versions of its CSS in-memory, which
+helps tremendously when you have a lot of workspace members all using a custom CSS version.</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+<li>
+<p><strong>Show prerelease contents on changelog pages - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/549" rel="noopener noreferrer">pr549</a></strong></p>
+<p>This is a simple bug fix. Previously, we accidentally hid the body of a prerelease on its own separate changelog page
+(but mysteriously, it showed up on the main changelog page when prereleases were toggled!)</p>
+</li>
+<li>
+<p><strong>Restrict parsed repo URLs to GitHub only - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/553" rel="noopener noreferrer">pr553</a></strong></p>
+<p>Right now, we only support GitHub repository URLs to get context from. This fixed an issue where technically, oranda
+would attempt to do this with GitLab URLs as well, which would cause unintended behavior.</p>
+</li>
+<li>
+<p><strong>Support <code>git+https</code> URLs</strong> - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/563" rel="noopener noreferrer">pr563</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/531" rel="noopener noreferrer">i531</a></p>
+<p>oranda now correctly handles <code>git+https://yourrepo</code> repository URLs, and is a lot more informative when it encounters
+one that it <em>can't</em> parse.</p>
+</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.3.0-prerelease.4">
+        <a href="v0.3.0-prerelease.4/">
+            
+                Version 0.3.0-prerelease.4
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.4
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  1 2023 at 09:17 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+<li>
+<p><strong>Basic CSS caching - <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/pull/551" rel="noopener noreferrer">pr551</a></strong></p>
+<p>In line with workspace support, oranda will now attempt to keep already downloaded versions of its CSS in-memory, which
+helps tremendously when you have a lot of workspace members all using the latest CSS version.</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+<li>
+<p><strong>Show prerelease contents on changelog pages - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/549" rel="noopener noreferrer">pr549</a></strong></p>
+<p>This is a simple bug fix. Previously, we accidentally hid the body of a prerelease on its own separate changelog page
+(but mysteriously, it showed up on the main changelog page when prereleases were toggled!)</p>
+</li>
+<li>
+<p><strong>Restrict parsed repo URLs to GitHub only - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/553" rel="noopener noreferrer">pr553</a></strong></p>
+<p>Right now, we only support GitHub repository URLs to get context from. This fixed an issue where technically, oranda
+would attempt to do this with GitLab URLs as well, which would cause unintended behavior.</p>
+</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.3.0-prerelease.3">
+        <a href="v0.3.0-prerelease.3/">
+            
+                Version 0.3.0-prerelease.3
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 26 2023 at 18:51 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+<li>
+<p><strong>Show prerelease contents on changelog pages - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/[pr549]</strong></p>
+<p>This is a simple bug fix. Previously, we accidentally hid the body of a prerelease on its own separate changelog page
+(but mysteriously, it showed up on the main changelog page when prereleases were toggled!)</p>
+</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.3.0-prerelease.2">
+        <a href="v0.3.0-prerelease.2/">
+            
+                Version 0.3.0-prerelease.2
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 26 2023 at 17:32 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.3.0-prerelease.1">
+        <a href="v0.3.0-prerelease.1/">
+            
+                Version 0.3.0-prerelease.1
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 25 2023 at 09:45 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.2.0">
+        <a href="v0.2.0/">
+            
+                0.2.0 - 2023-07-19
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.2.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 19 2023 at 16:06 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>BREAKING</h3>
+<ul>
+<li>
+<p><strong>make artifact autodetect configurable - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/527" rel="noopener noreferrer">pr527</a></strong></p>
+<p>We now provide a new boolean key, <code>components.artifacts.auto</code>, that lets you explicitly
+enable autodetection of artifacts. Previously, we would only enable this if you either
+turned on <code>components.artifacts.cargo_dist</code>, or if you provided some package manager entries.
+Since oranda <em>does</em> also support gleaning artifacts even without <code>cargo-dist</code> support enabled,
+we added this extra switch to let you toggle it without having to mess around with package managers.</p>
+<p>This is a <strong>breaking change</strong>, as enabling <code>cargo-dist</code> support or specifying package managers does
+not turn on auto-detection of artifacts anymore. If you were previously relying on auto-detection, your
+artifacts will no longer be displayed. To re-enable auto-detection, create a <code>oranda.json</code> file if you don't
+already have one, and set the following configuration:</p>
+<pre style="background-color:#263238;"><span style="color:#89ddff;">{
+</span><span style="color:#eeffff;">  </span><span style="color:#c792ea;">"components"</span><span style="color:#89ddff;">: {
+</span><span style="color:#eeffff;">    </span><span style="color:#ffcb6b;">"artifacts"</span><span style="color:#89ddff;">: {
+</span><span style="color:#eeffff;">      </span><span style="color:#f78c6c;">"auto"</span><span style="color:#89ddff;">: </span><span style="color:#f78c6c;">true
+</span><span style="color:#eeffff;">    </span><span style="color:#89ddff;">}
+</span><span style="color:#eeffff;">  </span><span style="color:#89ddff;">}
+</span><span style="color:#89ddff;">}
+</span></pre>
+
+</li>
+</ul>
+<h3>Features</h3>
+<ul>
+<li>
+<p><strong>Typescript syntax highlighting support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/525" rel="noopener noreferrer">pr525</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/513" rel="noopener noreferrer">i513</a></strong></p>
+<p>You can now use the <code>ts</code>/<code>typescript</code> languages in code blocks! Hooray for types!</p>
+</li>
+<li>
+<p><strong>Better logo positioning - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/524" rel="noopener noreferrer">pr524</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/519" rel="noopener noreferrer">i519</a></strong></p>
+<p>Logos set via the <code>styles.logo</code> option will now be properly centered/aligned in all themes,
+and set to a maximum width so that a 1920x1080 logo won't be displayed in its full width and height, thus
+pushing all content down below the fold.</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Hacker theme highlight color - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>, <a href="https://github.com/axodotdev/oranda/pull/523" rel="noopener noreferrer">pr523</a>/<a href="https://github.com/axodotdev/oranda/issues/522" rel="noopener noreferrer">i522</a></strong></p>
+<p>Selecting text in the Hacker theme now applies a nice, green, high contrast highlight background
+color, instead of being the same color as the text, therefore hiding the content.</p>
+</li>
+<li>
+<p><strong>Package managers documentation - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/521" rel="noopener noreferrer">pr521</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/520" rel="noopener noreferrer">i520</a></strong></p>
+<p>Some minor fixes to bring the package manager docs up to speed with how oranda actually processes options.</p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li>
+<p><strong>Refactor into using minijinja templates instead of axohtml - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/526" rel="noopener noreferrer">pr526</a></strong></p>
+<p>A biiig internal refactor moving us away from our previous typed-HTML-in-Rust approach of generating
+HTML, towards using a proper template language (Jinja2) instead. This allows for a lot more flexibility
+and separation of concerns going forward!</p>
+</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.2.0-prerelease.1">
+        <a href="v0.2.0-prerelease.1/">
+            
+                Version 0.2.0-prerelease.1
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.2.0-prerelease.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 14 2023 at 18:01 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>BREAKING</h3>
+<ul>
+<li><strong>make artifact autodetect configurable - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/527" rel="noopener noreferrer">pr527</a></strong></li>
+</ul>
+<h3>Features</h3>
+<ul>
+<li>
+<p><strong>Typescript syntax highlighting support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/525" rel="noopener noreferrer">pr525</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/513" rel="noopener noreferrer">i513</a></strong></p>
+</li>
+<li>
+<p><strong>Better logo positioning - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/524" rel="noopener noreferrer">pr524</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/519" rel="noopener noreferrer">i519</a></strong></p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Hacker theme highlight color - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>, <a href="https://github.com/axodotdev/oranda/pull/523" rel="noopener noreferrer">pr523</a>/<a href="https://github.com/axodotdev/oranda/issues/522" rel="noopener noreferrer">i522</a></strong></p>
+</li>
+<li>
+<p><strong>Package managers documentation - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/521" rel="noopener noreferrer">pr521</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/520" rel="noopener noreferrer">i520</a></strong></p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li><strong>Refactor into using minijinja templates instead of axohtml - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/526" rel="noopener noreferrer">pr526</a></strong></li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.1.1">
+        <a href="v0.1.1/">
+            
+                0.1.1 - 2023-07-04
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul  4 2023 at 17:13 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Remove OpenSSL dependency - <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/515" rel="noopener noreferrer">pr515</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/514" rel="noopener noreferrer">i514</a></strong></p>
+<p>If a release happens without an OpenSSL issue, does it really happen? In trying
+to run <code>oranda build</code> on a beta image for Cloudflare Pages, an end user discovered
+that we hadn't fully vanquished our dependency on OpenSSL. With this PR, we've
+made 100% sure we have.</p>
+</li>
+<li>
+<p><strong>Allow schema key in <code>oranda.json</code> - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>, <a href="https://github.com/axodotdev/oranda/pull/506" rel="noopener noreferrer">pr506</a></strong></p>
+<p>To improve the user experience of configuring oranda, we error on unexpected
+keys in the <code>oranda.json</code> file- which will help people see typos and other
+mistakes. However, this checking was over-eagerly erroring when folks added
+a schema key so they could use VS Code's schema support. This PR makes an
+exception for users including the "non-functional" (in oranda) schema key.</p>
+</li>
+<li>
+<p><strong>Add fallback to macOS Intel artifacts if Apple Silicon detected, but no artifacts found - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>, <a href="https://github.com/axodotdev/oranda/pull/511" rel="noopener noreferrer">pr511</a></strong></p>
+<p>Platform support and detection is slightly more complicated on Apple/macOS
+machines because Apple offers Rosetta2 which allows you to run binaries built
+for older Intel-based systems on the new Apple Silicon ones (but not vice versa).
+This PR updates the install widget's behavior to show artifacts built for
+Apple Intel-based systems if it detects an Apple Silicon system but cannot find
+any binaries built for Apple Silicon.</p>
+</li>
+<li>
+<p><strong>Artifact table width on mobile - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>, <a href="https://github.com/axodotdev/oranda/pull/505" rel="noopener noreferrer">pr505</a></strong></p>
+<p>On mobile, the artifact table's width was forcing a scroll. We've updated the
+CSS to fix this!</p>
+</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.1.0">
+        <a href="v0.1.0/">
+            
+                0.1.0 - 2023-07-03
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul  3 2023 at 14:30 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>What is oranda?</h3>
+<p>oranda is a hands-off static site generator for people who want a website for their tool but don't want to get knee-deep into web development. As long as you have a <code>README.md</code> in your directory, you can benefit from oranda. oranda will also try to automatically work with:</p>
+<ul>
+<li>Release artifacts (currently only for GitHub releases)
+<ul>
+<li><code>cargo-dist</code>-generated ones, and</li>
+<li>arbitrary release artifacts</li>
+</ul>
+</li>
+<li><code>mdbook</code>docs</li>
+<li>GitHub-supported project/maintainer funding sources</li>
+</ul>
+<p>oranda is designed to <em>just work</em> in a lot of cases, and in cases where it doesn't, it should provide fine-grained configuration so you can make it work for your use case.</p>
+<h3>Features</h3>
+<h4>Components</h4>
+<h5>Github release artifacts inference</h5>
+<p>We can now not only figure out whether you're using <code>cargo-dist</code> <em>automatically</em>, but we also try and support arbitrary tarballs, as long as they're attached to a release and they're following the target-triple format. Oranda will now, for example, pick up a release artifact called <code>myapp-aarch64-apple-darwin.tar.xz</code>, even if the project isn't using <code>cargo-dist</code> to publish releases.</p>
+<h5>Smarter install widget</h5>
+<p>The installer widget on our main page has been upgraded! It now not only shows a select box where you can switch between different architectures (though we still attempt to figure out what platform you're running on), but it now additionally displays your package managers, all in a sleek tab-style view:</p>
+<p><img src="https://github-production-user-asset-6210df.s3.amazonaws.com/6445316/250566861-a635c28b-d4d3-4c90-a685-8e9a85673651.png" alt="oranda install widget preview"></p>
+<p>You can customize which package managers you want to be displayed on in this widget vs. which ones should only be displayed on the separate install page, as well. <a href="https://opensource.axo.dev/oranda/book/configuration/artifacts.html#adding-package-manager-installation-instructions" rel="noopener noreferrer">Read more in the docs</a></p>
+<h5>Funding page</h5>
+<p>oranda now has the ability to autodetect whether you're using GitHub's funding embed functionality (meaning you have a <code>.github/FUNDING.yml</code>), in which case it'll automatically generate a page showing your available funding options.</p>
+<p>Additionally, you can enhance this page by selecting a particular funding channel to be prioritized as your "main" funding method. You can also provide custom content from a <code>funding.md</code> Markdown file, to provide additional context to your funding page. <a href="https://opensource.axo.dev/oranda/book/configuration/funding.html" rel="noopener noreferrer">Read more in the docs</a></p>
+<p>This is less of a defined feature and more of an experiment on how we can better integrate maintainers' funding sources onto their websites. Please let us know what you think, or if you have any other feedback or input!</p>
+<h5><code>mdbook</code> autodetect and styling</h5>
+<p>oranda themes now get applied to your mdbook output, too, meaning there's less of a discrepancy between your flashy oranda page and your default-mdbook-styled docs. We've also been hard at work being able to detect when you use <code>mdbook</code> without you having to set it, which should now work in the majority of cases.</p>
+<h4>Configuration</h4>
+<h5>New configuration structure</h5>
+<p>We've completely revamped our configuration structure to be more future-proof and to require less refactoring in the fullness of time. For the new configuration layout, please <a href="https://opensource.axo.dev/oranda/book/configuration.html" rel="noopener noreferrer">consult the docs</a>.</p>
+<p>One other major change is that we now <strong>reject unknown config keys</strong>. This means that if you've had a oranda 0.0.3 site, it will now force you to migrate your config to the new format. We've decided on this because we believe that doing anything but hard erroring in this situation would lead to unwanted behavior (old keys getting interpreted in new, weird ways, and so on).</p>
+<h5>Config schema</h5>
+<p>oranda's configuration schema is now available in a JSON schema for each release starting with this one. This means that in editors like VSCode, you can attach the schema to your <code>oranda.json</code> file and get autofill and documentation, like this:</p>
+<pre style="background-color:#263238;"><span style="color:#89ddff;">{
+</span><span style="color:#eeffff;">  </span><span style="color:#c792ea;">"$schema"</span><span style="color:#89ddff;">: "</span><span style="color:#c3e88d;">https://github.com/axodotdev/oranda/releases/download/v0.1.0/oranda-config-schema.json</span><span style="color:#89ddff;">"
+</span><span style="color:#89ddff;">}
+</span></pre>
+
+<h4>CLI</h4>
+<h5><code>dev</code> command</h5>
+<p>This release introduces <code>oranda dev</code>, which bundles both building your site and serving it from a file server, as well as sprinkling in auto-recompilation when files change. It's intended to be the prime command for local development of a oranda site.</p>
+<h3>Bug fixes</h3>
+<p>(this is a selection, there's been way too many to fully list, at least until we're able to automatically generate a list)</p>
+<ul>
+<li>Various style fixes, lists now display correct, colors should be less offensive to the eye, that sort of stuff</li>
+<li>We're much better now at handling complex release histories!</li>
+<li>We've completely removed the <code>version</code> key from the configuration. It wasn't used, and we probably won't use it in the future, either</li>
+</ul>
+<h3>Docs</h3>
+<p>Documentation has had a major rewrite! We now provide a full configuration overview, as well as more detailed writeups for major parts of functionality.</p>
+<h3>Thank you to our contributors!</h3>
+<p>Despite being formally unannounced, several intrepid folks discovered oranda, and have been using it for personal projects and contributing issues and PRs. Their feedback has been invaluable in getting oranda to 0.1.0 today and we'd like to thank them:</p>
+<ul>
+<li><a href="https://github.com/2mill" rel="noopener noreferrer">2mill</a></li>
+<li><a href="https://github.com/andrewmd5" rel="noopener noreferrer">andrewmd5</a></li>
+<li><a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a></li>
+<li><a href="https://github.com/MarcoIeni" rel="noopener noreferrer">MarcoIeni</a></li>
+<li><a href="https://github.com/msfjarvis" rel="noopener noreferrer">msjarvis</a></li>
+<li><a href="https://github.com/pomdtr" rel="noopener noreferrer">pomdtr</a></li>
+<li><a href="https://github.com/proofconstruction" rel="noopener noreferrer">proofconstruction</a></li>
+<li><a href="https://github.com/tshepang" rel="noopener noreferrer">tshepang</a></li>
+<li><a href="https://github.com/untitaker" rel="noopener noreferrer">untitaker</a></li>
+<li><a href="https://github.com/zkat" rel="noopener noreferrer">zkat</a></li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.9">
+        <a href="v0.1.0-prerelease.9/">
+            
+                Version 0.1.0-prerelease.9
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.9
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 28 2023 at 16:47 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.8">
+        <a href="v0.1.0-prerelease.8/">
+            
+                Version 0.1.0-prerelease.8
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.8
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 21 2023 at 20:28 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.7">
+        <a href="v0.1.0-prerelease.7/">
+            
+                Version 0.1.0-prerelease.7
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.7
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 20 2023 at 15:23 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.7">
+        <a href="css-v0.0.7/">
+            
+                css-v0.0.7
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.7
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 20 2023 at 14:51 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.6">
+        <a href="css-v0.0.6/">
+            
+                css-v0.0.6
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.6
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 19 2023 at 23:57 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.6">
+        <a href="v0.1.0-prerelease.6/">
+            
+                Version 0.1.0-prerelease.6
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.6
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 12 2023 at 15:01 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.5">
+        <a href="css-v0.0.5/">
+            
+                css-v0.0.5
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.5
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 12 2023 at 13:43 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.5">
+        <a href="v0.1.0-prerelease.5/">
+            
+                Version 0.1.0-prerelease.5
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.5
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 30 2023 at 16:24 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.4">
+        <a href="v0.1.0-prerelease.4/">
+            
+                Version 0.1.0-prerelease.4
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.4
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 22 2023 at 20:08 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.3">
+        <a href="v0.1.0-prerelease.3/">
+            
+                Version 0.1.0-prerelease.3
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 22 2023 at 18:10 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.2">
+        <a href="v0.1.0-prerelease.2/">
+            
+                Version 0.1.0-prerelease.2
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 17 2023 at 15:10 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.1.0-prerelease.1">
+        <a href="v0.1.0-prerelease.1/">
+            
+                Version 0.1.0-prerelease.1
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 17 2023 at 00:39 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.0.3">
+        <a href="v0.0.3/">
+            
+                0.0.3 - 2023-05-08
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May  9 2023 at 01:15 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Individual Changelog pages: <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/284" rel="noopener noreferrer">↬284</a></strong></p>
+<p>When announcing a new release- it's often desirable to link to an individual
+release page that contains the changelog/release notes. Previously, we built
+a single page for all the releases- now we build individual pages as well.</p>
+<p>This is the first shipped feature from our new team member, Liv! Yay and
+welcome :)</p>
+</li>
+<li>
+<p><strong>npm installer: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/288" rel="noopener noreferrer">↬288</a></strong></p>
+<p>As of 0.0.6, <code>cargo-dist</code> will build an npm installer for you! So now you
+can npm or npx oranda!</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Improved configuration support for non-cargo dist users: <a href="https://github.com/pomdtr" rel="noopener noreferrer">pomdtr</a>/<a href="https://github.com/axodotdev/oranda/issues/262" rel="noopener noreferrer">#262</a> , <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/281" rel="noopener noreferrer">↬281</a></strong></p>
+<p>Previously, setting <code>cargo-dist</code> as false, or omitting it should have been
+sufficient to stop oranda from attempting to parse your releases as
+cargo-dist artifacts, however <code>cargo-dist: false</code> did not work! How the
+entire artifacts config object is handled has been reworked and tested.
+Additionally, work from a refactor has also made projects with a mixture of
+cargo-dist and non-cargo-dist releases work much better.</p>
+</li>
+<li>
+<p><strong>Installer header fallback when platform is not detected: <a href="https://github.com/gankra" rel="noopener noreferrer">gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/269" rel="noopener noreferrer">↬269</a></strong></p>
+<p>When you use cargo-dist, we display a header on your index page that
+detects your user's platform and recommends and installer to them. We did
+not previously have a fallback if we detected a system that none of the
+installers supported. Now, in that scenario- we'll offer an artifact
+download as the header option.</p>
+</li>
+<li>
+<p><strong>Dev commands has proper default values: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/256" rel="noopener noreferrer">#256</a>,<a href="https://github.com/axodotdev/oranda/pull/260" rel="noopener noreferrer">↬260</a></strong></p>
+<p>Due to a false hope that <code>#[derive(Default)]</code> would collect defaults from
+the <code>clap</code> derive API, we shipped the <code>dev</code> command with each argument's
+<em>type's</em> defaults, not the oranda ones. <code>dev</code> now has the same defaults
+that <code>serve</code> does, as is to be expected.</p>
+</li>
+<li>
+<p><strong>Improved typography and layout styles on mobile: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/234" rel="noopener noreferrer">#234</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/276" rel="noopener noreferrer">↬276</a></strong></p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li><strong>Re-add mdbook: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/190" rel="noopener noreferrer">#190</a>, <a href="https://github.com/gankra" rel="noopener noreferrer">gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/285" rel="noopener noreferrer">↬285</a></strong></li>
+<li><strong>Data fetching refactor: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/226" rel="noopener noreferrer">#226</a>,<a href="https://github.com/axodotdev/oranda/pull/274" rel="noopener noreferrer">↬274</a></strong></li>
+<li><strong>Update actions/checkout to v3: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/251" rel="noopener noreferrer">#251</a>,<a href="https://github.com/axodotdev/oranda/pull/255" rel="noopener noreferrer">↬255</a></strong></li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.4">
+        <a href="css-v0.0.4/">
+            
+                css-v0.0.4
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.4
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May  9 2023 at 00:21 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.3">
+        <a href="css-v0.0.3/">
+            
+                css-v0.0.3
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May  8 2023 at 23:08 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.0.2">
+        <a href="v0.0.2/">
+            
+                0.0.2 - 2023-04-13
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Apr 14 2023 at 16:39 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Changelogs - <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/192" rel="noopener noreferrer">#192</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/193" rel="noopener noreferrer">↬193</a></strong></p>
+</li>
+<li>
+<p><strong><code>oranda dev</code> command v1: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/209" rel="noopener noreferrer">#209</a>,<a href="https://github.com/axodotdev/oranda/pull/240" rel="noopener noreferrer">↬240</a></strong></p>
+<p>It is common to run <code>oranda build &amp;&amp; oranda serve</code> so <code>oranda dev</code> now wraps
+that into a single function. A future version will improve this to include
+watching to automatically rebuild on changes, while serve continues to run
+uninterrupted.`</p>
+</li>
+<li>
+<p><strong>Additional pages takes a hashmap to allow custom nav names: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/115" rel="noopener noreferrer">#115</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/203" rel="noopener noreferrer">↬203</a></strong></p>
+<p>Previously, the nav element for an additional page was inferred from its filename.
+However, this led to some unfortunate presentations- especially if the additional
+page had an all caps filename while others did not. This new data structure
+allows you to provide the specific string you'd like to see in the nav for
+any additional page.</p>
+</li>
+<li>
+<p><strong>Improved error handling: <a href="https://github.com/spitfire05" rel="noopener noreferrer">spitfire05</a>/<a href="https://github.com/axodotdev/oranda/issues/206" rel="noopener noreferrer">#206</a>, <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/191" rel="noopener noreferrer">↬191</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/193" rel="noopener noreferrer">↬193</a>,<a href="https://github.com/axodotdev/oranda/pull/201" rel="noopener noreferrer">↬201</a></strong></p>
+<p>Several PRs over the course of the last milestone have dramatically improved
+error handling: from replacing panics with proper errors to adding more
+descriptive errors with messages that help you better understand and solve
+the issue.</p>
+</li>
+<li>
+<p><strong>Themes: <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/208" rel="noopener noreferrer">↬208</a></strong></p>
+<p>There are now 2 additional themes- light(default), dark, hacker, and cupcake.</p>
+</li>
+<li>
+<p><strong>Version number and publish date on installer header: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/194" rel="noopener noreferrer">#194</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/217" rel="noopener noreferrer">↬217</a></strong></p>
+</li>
+<li>
+<p><strong>Improved styling: <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/202" rel="noopener noreferrer">↬202</a>,<a href="https://github.com/axodotdev/oranda/pull/220" rel="noopener noreferrer">↬220</a></strong></p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Code block with unsupported highlight annotations should show as plaintext: <a href="https://github.com/spitfire05" rel="noopener noreferrer">spitfire05</a>/<a href="https://github.com/axodotdev/oranda/issues/236" rel="noopener noreferrer">#236</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/237" rel="noopener noreferrer">↬237</a></strong></p>
+<p>Annotating a code block with an unsupported language highlight led to blocks
+simply not rendering at all. Now they will render as plainttext and will show
+a warning to request support.</p>
+</li>
+<li>
+<p><strong>Nav should show if using dist/changelog, but not additional pages: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/183" rel="noopener noreferrer">#183</a>,<a href="https://github.com/axodotdev/oranda/pull/187" rel="noopener noreferrer">↬187</a></strong></p>
+<p>Originally, we would only generate a nav if a user configured additional
+markdown pages. However, nav is also needed if a user configures their
+project to use cargo-dist or render changelogs.</p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li><strong>Update cargo-dist to enable Mac ARM builds: <a href="https://github.com/pomdtr" rel="noopener noreferrer">pomdtr</a>/<a href="https://github.com/axodotdev/oranda/issues/198" rel="noopener noreferrer">#198</a>, <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/248" rel="noopener noreferrer">↬248</a></strong></li>
+</ul>
+
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.2">
+        <a href="css-v0.0.2/">
+            
+                css-v0.0.2
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Mar 21 2023 at 21:46 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.1">
+        <a href="css-v0.0.1/">
+            
+                css-v0.0.1
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Mar 17 2023 at 12:45 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-css-v0.0.0">
+        <a href="css-v0.0.0/">
+            
+                css-v0.0.0
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            css-v0.0.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Mar  8 2023 at 14:47 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.0.1">
+        <a href="v0.0.1/">
+            
+                0.0.1 - 2023-02-24
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Feb 24 2023 at 22:56 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>Initial release.</p>
+
+    </div>
+</section>
+            
+                
+                <section class="release pre-release hidden">
+    <h2 id="tag-v0.0.1-prerelease2">
+        <a href="v0.0.1-prerelease2/">
+            
+                v0.0.1-prerelease2
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.1-prerelease2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Feb 24 2023 at 21:35 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+        </div>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+<script src="/oranda/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/changelog/v0.0.1/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>0.0.1 - 2023-02-24</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Feb 24 2023 at 22:56 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>Initial release.</p>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.0.1-prerelease2/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>v0.0.1-prerelease2</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.1-prerelease2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Feb 24 2023 at 21:35 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.0.2/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>0.0.2 - 2023-04-13</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Apr 14 2023 at 16:39 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Changelogs - <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/192" rel="noopener noreferrer">#192</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/193" rel="noopener noreferrer">↬193</a></strong></p>
+</li>
+<li>
+<p><strong><code>oranda dev</code> command v1: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/209" rel="noopener noreferrer">#209</a>,<a href="https://github.com/axodotdev/oranda/pull/240" rel="noopener noreferrer">↬240</a></strong></p>
+<p>It is common to run <code>oranda build &amp;&amp; oranda serve</code> so <code>oranda dev</code> now wraps
+that into a single function. A future version will improve this to include
+watching to automatically rebuild on changes, while serve continues to run
+uninterrupted.`</p>
+</li>
+<li>
+<p><strong>Additional pages takes a hashmap to allow custom nav names: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/115" rel="noopener noreferrer">#115</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/203" rel="noopener noreferrer">↬203</a></strong></p>
+<p>Previously, the nav element for an additional page was inferred from its filename.
+However, this led to some unfortunate presentations- especially if the additional
+page had an all caps filename while others did not. This new data structure
+allows you to provide the specific string you'd like to see in the nav for
+any additional page.</p>
+</li>
+<li>
+<p><strong>Improved error handling: <a href="https://github.com/spitfire05" rel="noopener noreferrer">spitfire05</a>/<a href="https://github.com/axodotdev/oranda/issues/206" rel="noopener noreferrer">#206</a>, <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/191" rel="noopener noreferrer">↬191</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/193" rel="noopener noreferrer">↬193</a>,<a href="https://github.com/axodotdev/oranda/pull/201" rel="noopener noreferrer">↬201</a></strong></p>
+<p>Several PRs over the course of the last milestone have dramatically improved
+error handling: from replacing panics with proper errors to adding more
+descriptive errors with messages that help you better understand and solve
+the issue.</p>
+</li>
+<li>
+<p><strong>Themes: <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/208" rel="noopener noreferrer">↬208</a></strong></p>
+<p>There are now 2 additional themes- light(default), dark, hacker, and cupcake.</p>
+</li>
+<li>
+<p><strong>Version number and publish date on installer header: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/194" rel="noopener noreferrer">#194</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/217" rel="noopener noreferrer">↬217</a></strong></p>
+</li>
+<li>
+<p><strong>Improved styling: <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/202" rel="noopener noreferrer">↬202</a>,<a href="https://github.com/axodotdev/oranda/pull/220" rel="noopener noreferrer">↬220</a></strong></p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Code block with unsupported highlight annotations should show as plaintext: <a href="https://github.com/spitfire05" rel="noopener noreferrer">spitfire05</a>/<a href="https://github.com/axodotdev/oranda/issues/236" rel="noopener noreferrer">#236</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/237" rel="noopener noreferrer">↬237</a></strong></p>
+<p>Annotating a code block with an unsupported language highlight led to blocks
+simply not rendering at all. Now they will render as plainttext and will show
+a warning to request support.</p>
+</li>
+<li>
+<p><strong>Nav should show if using dist/changelog, but not additional pages: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/183" rel="noopener noreferrer">#183</a>,<a href="https://github.com/axodotdev/oranda/pull/187" rel="noopener noreferrer">↬187</a></strong></p>
+<p>Originally, we would only generate a nav if a user configured additional
+markdown pages. However, nav is also needed if a user configures their
+project to use cargo-dist or render changelogs.</p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li><strong>Update cargo-dist to enable Mac ARM builds: <a href="https://github.com/pomdtr" rel="noopener noreferrer">pomdtr</a>/<a href="https://github.com/axodotdev/oranda/issues/198" rel="noopener noreferrer">#198</a>, <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/248" rel="noopener noreferrer">↬248</a></strong></li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.0.3/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>0.0.3 - 2023-05-08</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.0.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May  9 2023 at 01:15 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Individual Changelog pages: <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/284" rel="noopener noreferrer">↬284</a></strong></p>
+<p>When announcing a new release- it's often desirable to link to an individual
+release page that contains the changelog/release notes. Previously, we built
+a single page for all the releases- now we build individual pages as well.</p>
+<p>This is the first shipped feature from our new team member, Liv! Yay and
+welcome :)</p>
+</li>
+<li>
+<p><strong>npm installer: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/288" rel="noopener noreferrer">↬288</a></strong></p>
+<p>As of 0.0.6, <code>cargo-dist</code> will build an npm installer for you! So now you
+can npm or npx oranda!</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Improved configuration support for non-cargo dist users: <a href="https://github.com/pomdtr" rel="noopener noreferrer">pomdtr</a>/<a href="https://github.com/axodotdev/oranda/issues/262" rel="noopener noreferrer">#262</a> , <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/281" rel="noopener noreferrer">↬281</a></strong></p>
+<p>Previously, setting <code>cargo-dist</code> as false, or omitting it should have been
+sufficient to stop oranda from attempting to parse your releases as
+cargo-dist artifacts, however <code>cargo-dist: false</code> did not work! How the
+entire artifacts config object is handled has been reworked and tested.
+Additionally, work from a refactor has also made projects with a mixture of
+cargo-dist and non-cargo-dist releases work much better.</p>
+</li>
+<li>
+<p><strong>Installer header fallback when platform is not detected: <a href="https://github.com/gankra" rel="noopener noreferrer">gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/269" rel="noopener noreferrer">↬269</a></strong></p>
+<p>When you use cargo-dist, we display a header on your index page that
+detects your user's platform and recommends and installer to them. We did
+not previously have a fallback if we detected a system that none of the
+installers supported. Now, in that scenario- we'll offer an artifact
+download as the header option.</p>
+</li>
+<li>
+<p><strong>Dev commands has proper default values: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/256" rel="noopener noreferrer">#256</a>,<a href="https://github.com/axodotdev/oranda/pull/260" rel="noopener noreferrer">↬260</a></strong></p>
+<p>Due to a false hope that <code>#[derive(Default)]</code> would collect defaults from
+the <code>clap</code> derive API, we shipped the <code>dev</code> command with each argument's
+<em>type's</em> defaults, not the oranda ones. <code>dev</code> now has the same defaults
+that <code>serve</code> does, as is to be expected.</p>
+</li>
+<li>
+<p><strong>Improved typography and layout styles on mobile: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/234" rel="noopener noreferrer">#234</a>, <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/276" rel="noopener noreferrer">↬276</a></strong></p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li><strong>Re-add mdbook: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/190" rel="noopener noreferrer">#190</a>, <a href="https://github.com/gankra" rel="noopener noreferrer">gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/285" rel="noopener noreferrer">↬285</a></strong></li>
+<li><strong>Data fetching refactor: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/226" rel="noopener noreferrer">#226</a>,<a href="https://github.com/axodotdev/oranda/pull/274" rel="noopener noreferrer">↬274</a></strong></li>
+<li><strong>Update actions/checkout to v3: <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/issues/251" rel="noopener noreferrer">#251</a>,<a href="https://github.com/axodotdev/oranda/pull/255" rel="noopener noreferrer">↬255</a></strong></li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>0.1.0 - 2023-07-03</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul  3 2023 at 14:30 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>What is oranda?</h3>
+<p>oranda is a hands-off static site generator for people who want a website for their tool but don't want to get knee-deep into web development. As long as you have a <code>README.md</code> in your directory, you can benefit from oranda. oranda will also try to automatically work with:</p>
+<ul>
+<li>Release artifacts (currently only for GitHub releases)
+<ul>
+<li><code>cargo-dist</code>-generated ones, and</li>
+<li>arbitrary release artifacts</li>
+</ul>
+</li>
+<li><code>mdbook</code>docs</li>
+<li>GitHub-supported project/maintainer funding sources</li>
+</ul>
+<p>oranda is designed to <em>just work</em> in a lot of cases, and in cases where it doesn't, it should provide fine-grained configuration so you can make it work for your use case.</p>
+<h3>Features</h3>
+<h4>Components</h4>
+<h5>Github release artifacts inference</h5>
+<p>We can now not only figure out whether you're using <code>cargo-dist</code> <em>automatically</em>, but we also try and support arbitrary tarballs, as long as they're attached to a release and they're following the target-triple format. Oranda will now, for example, pick up a release artifact called <code>myapp-aarch64-apple-darwin.tar.xz</code>, even if the project isn't using <code>cargo-dist</code> to publish releases.</p>
+<h5>Smarter install widget</h5>
+<p>The installer widget on our main page has been upgraded! It now not only shows a select box where you can switch between different architectures (though we still attempt to figure out what platform you're running on), but it now additionally displays your package managers, all in a sleek tab-style view:</p>
+<p><img src="https://github-production-user-asset-6210df.s3.amazonaws.com/6445316/250566861-a635c28b-d4d3-4c90-a685-8e9a85673651.png" alt="oranda install widget preview"></p>
+<p>You can customize which package managers you want to be displayed on in this widget vs. which ones should only be displayed on the separate install page, as well. <a href="https://opensource.axo.dev/oranda/book/configuration/artifacts.html#adding-package-manager-installation-instructions" rel="noopener noreferrer">Read more in the docs</a></p>
+<h5>Funding page</h5>
+<p>oranda now has the ability to autodetect whether you're using GitHub's funding embed functionality (meaning you have a <code>.github/FUNDING.yml</code>), in which case it'll automatically generate a page showing your available funding options.</p>
+<p>Additionally, you can enhance this page by selecting a particular funding channel to be prioritized as your "main" funding method. You can also provide custom content from a <code>funding.md</code> Markdown file, to provide additional context to your funding page. <a href="https://opensource.axo.dev/oranda/book/configuration/funding.html" rel="noopener noreferrer">Read more in the docs</a></p>
+<p>This is less of a defined feature and more of an experiment on how we can better integrate maintainers' funding sources onto their websites. Please let us know what you think, or if you have any other feedback or input!</p>
+<h5><code>mdbook</code> autodetect and styling</h5>
+<p>oranda themes now get applied to your mdbook output, too, meaning there's less of a discrepancy between your flashy oranda page and your default-mdbook-styled docs. We've also been hard at work being able to detect when you use <code>mdbook</code> without you having to set it, which should now work in the majority of cases.</p>
+<h4>Configuration</h4>
+<h5>New configuration structure</h5>
+<p>We've completely revamped our configuration structure to be more future-proof and to require less refactoring in the fullness of time. For the new configuration layout, please <a href="https://opensource.axo.dev/oranda/book/configuration.html" rel="noopener noreferrer">consult the docs</a>.</p>
+<p>One other major change is that we now <strong>reject unknown config keys</strong>. This means that if you've had a oranda 0.0.3 site, it will now force you to migrate your config to the new format. We've decided on this because we believe that doing anything but hard erroring in this situation would lead to unwanted behavior (old keys getting interpreted in new, weird ways, and so on).</p>
+<h5>Config schema</h5>
+<p>oranda's configuration schema is now available in a JSON schema for each release starting with this one. This means that in editors like VSCode, you can attach the schema to your <code>oranda.json</code> file and get autofill and documentation, like this:</p>
+<pre style="background-color:#263238;"><span style="color:#89ddff;">{
+</span><span style="color:#eeffff;">  </span><span style="color:#c792ea;">"$schema"</span><span style="color:#89ddff;">: "</span><span style="color:#c3e88d;">https://github.com/axodotdev/oranda/releases/download/v0.1.0/oranda-config-schema.json</span><span style="color:#89ddff;">"
+</span><span style="color:#89ddff;">}
+</span></pre>
+
+<h4>CLI</h4>
+<h5><code>dev</code> command</h5>
+<p>This release introduces <code>oranda dev</code>, which bundles both building your site and serving it from a file server, as well as sprinkling in auto-recompilation when files change. It's intended to be the prime command for local development of a oranda site.</p>
+<h3>Bug fixes</h3>
+<p>(this is a selection, there's been way too many to fully list, at least until we're able to automatically generate a list)</p>
+<ul>
+<li>Various style fixes, lists now display correct, colors should be less offensive to the eye, that sort of stuff</li>
+<li>We're much better now at handling complex release histories!</li>
+<li>We've completely removed the <code>version</code> key from the configuration. It wasn't used, and we probably won't use it in the future, either</li>
+</ul>
+<h3>Docs</h3>
+<p>Documentation has had a major rewrite! We now provide a full configuration overview, as well as more detailed writeups for major parts of functionality.</p>
+<h3>Thank you to our contributors!</h3>
+<p>Despite being formally unannounced, several intrepid folks discovered oranda, and have been using it for personal projects and contributing issues and PRs. Their feedback has been invaluable in getting oranda to 0.1.0 today and we'd like to thank them:</p>
+<ul>
+<li><a href="https://github.com/2mill" rel="noopener noreferrer">2mill</a></li>
+<li><a href="https://github.com/andrewmd5" rel="noopener noreferrer">andrewmd5</a></li>
+<li><a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a></li>
+<li><a href="https://github.com/MarcoIeni" rel="noopener noreferrer">MarcoIeni</a></li>
+<li><a href="https://github.com/msfjarvis" rel="noopener noreferrer">msjarvis</a></li>
+<li><a href="https://github.com/pomdtr" rel="noopener noreferrer">pomdtr</a></li>
+<li><a href="https://github.com/proofconstruction" rel="noopener noreferrer">proofconstruction</a></li>
+<li><a href="https://github.com/tshepang" rel="noopener noreferrer">tshepang</a></li>
+<li><a href="https://github.com/untitaker" rel="noopener noreferrer">untitaker</a></li>
+<li><a href="https://github.com/zkat" rel="noopener noreferrer">zkat</a></li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.1/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.1</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 17 2023 at 00:39 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.2/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.2</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 17 2023 at 15:10 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.3/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.3</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 22 2023 at 18:10 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.4/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.4</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.4
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 22 2023 at 20:08 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.5/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.5</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.5
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                May 30 2023 at 16:24 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.6/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.6</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.6
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 12 2023 at 15:01 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.7/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.7</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.7
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 20 2023 at 15:23 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.8/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.8</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.8
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 21 2023 at 20:28 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.0-prerelease.9/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.1.0-prerelease.9</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0-prerelease.9
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jun 28 2023 at 16:47 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <p>FIXME: write a proper changelog for the next release</p>
+<ul>
+<li>various fixes</li>
+<li>much faster</li>
+<li>mdbook integration change</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.1.1/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>0.1.1 - 2023-07-04</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul  4 2023 at 17:13 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Remove OpenSSL dependency - <a href="https://github.com/ashleygwilliams" rel="noopener noreferrer">ashleygwilliams</a>/<a href="https://github.com/axodotdev/oranda/pull/515" rel="noopener noreferrer">pr515</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/514" rel="noopener noreferrer">i514</a></strong></p>
+<p>If a release happens without an OpenSSL issue, does it really happen? In trying
+to run <code>oranda build</code> on a beta image for Cloudflare Pages, an end user discovered
+that we hadn't fully vanquished our dependency on OpenSSL. With this PR, we've
+made 100% sure we have.</p>
+</li>
+<li>
+<p><strong>Allow schema key in <code>oranda.json</code> - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>, <a href="https://github.com/axodotdev/oranda/pull/506" rel="noopener noreferrer">pr506</a></strong></p>
+<p>To improve the user experience of configuring oranda, we error on unexpected
+keys in the <code>oranda.json</code> file- which will help people see typos and other
+mistakes. However, this checking was over-eagerly erroring when folks added
+a schema key so they could use VS Code's schema support. This PR makes an
+exception for users including the "non-functional" (in oranda) schema key.</p>
+</li>
+<li>
+<p><strong>Add fallback to macOS Intel artifacts if Apple Silicon detected, but no artifacts found - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>, <a href="https://github.com/axodotdev/oranda/pull/511" rel="noopener noreferrer">pr511</a></strong></p>
+<p>Platform support and detection is slightly more complicated on Apple/macOS
+machines because Apple offers Rosetta2 which allows you to run binaries built
+for older Intel-based systems on the new Apple Silicon ones (but not vice versa).
+This PR updates the install widget's behavior to show artifacts built for
+Apple Intel-based systems if it detects an Apple Silicon system but cannot find
+any binaries built for Apple Silicon.</p>
+</li>
+<li>
+<p><strong>Artifact table width on mobile - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>, <a href="https://github.com/axodotdev/oranda/pull/505" rel="noopener noreferrer">pr505</a></strong></p>
+<p>On mobile, the artifact table's width was forcing a scroll. We've updated the
+CSS to fix this!</p>
+</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.2.0/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>0.2.0 - 2023-07-19</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.2.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 19 2023 at 16:06 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>BREAKING</h3>
+<ul>
+<li>
+<p><strong>make artifact autodetect configurable - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/527" rel="noopener noreferrer">pr527</a></strong></p>
+<p>We now provide a new boolean key, <code>components.artifacts.auto</code>, that lets you explicitly
+enable autodetection of artifacts. Previously, we would only enable this if you either
+turned on <code>components.artifacts.cargo_dist</code>, or if you provided some package manager entries.
+Since oranda <em>does</em> also support gleaning artifacts even without <code>cargo-dist</code> support enabled,
+we added this extra switch to let you toggle it without having to mess around with package managers.</p>
+<p>This is a <strong>breaking change</strong>, as enabling <code>cargo-dist</code> support or specifying package managers does
+not turn on auto-detection of artifacts anymore. If you were previously relying on auto-detection, your
+artifacts will no longer be displayed. To re-enable auto-detection, create a <code>oranda.json</code> file if you don't
+already have one, and set the following configuration:</p>
+<pre style="background-color:#263238;"><span style="color:#89ddff;">{
+</span><span style="color:#eeffff;">  </span><span style="color:#c792ea;">"components"</span><span style="color:#89ddff;">: {
+</span><span style="color:#eeffff;">    </span><span style="color:#ffcb6b;">"artifacts"</span><span style="color:#89ddff;">: {
+</span><span style="color:#eeffff;">      </span><span style="color:#f78c6c;">"auto"</span><span style="color:#89ddff;">: </span><span style="color:#f78c6c;">true
+</span><span style="color:#eeffff;">    </span><span style="color:#89ddff;">}
+</span><span style="color:#eeffff;">  </span><span style="color:#89ddff;">}
+</span><span style="color:#89ddff;">}
+</span></pre>
+
+</li>
+</ul>
+<h3>Features</h3>
+<ul>
+<li>
+<p><strong>Typescript syntax highlighting support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/525" rel="noopener noreferrer">pr525</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/513" rel="noopener noreferrer">i513</a></strong></p>
+<p>You can now use the <code>ts</code>/<code>typescript</code> languages in code blocks! Hooray for types!</p>
+</li>
+<li>
+<p><strong>Better logo positioning - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/524" rel="noopener noreferrer">pr524</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/519" rel="noopener noreferrer">i519</a></strong></p>
+<p>Logos set via the <code>styles.logo</code> option will now be properly centered/aligned in all themes,
+and set to a maximum width so that a 1920x1080 logo won't be displayed in its full width and height, thus
+pushing all content down below the fold.</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Hacker theme highlight color - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>, <a href="https://github.com/axodotdev/oranda/pull/523" rel="noopener noreferrer">pr523</a>/<a href="https://github.com/axodotdev/oranda/issues/522" rel="noopener noreferrer">i522</a></strong></p>
+<p>Selecting text in the Hacker theme now applies a nice, green, high contrast highlight background
+color, instead of being the same color as the text, therefore hiding the content.</p>
+</li>
+<li>
+<p><strong>Package managers documentation - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/521" rel="noopener noreferrer">pr521</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/520" rel="noopener noreferrer">i520</a></strong></p>
+<p>Some minor fixes to bring the package manager docs up to speed with how oranda actually processes options.</p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li>
+<p><strong>Refactor into using minijinja templates instead of axohtml - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/526" rel="noopener noreferrer">pr526</a></strong></p>
+<p>A biiig internal refactor moving us away from our previous typed-HTML-in-Rust approach of generating
+HTML, towards using a proper template language (Jinja2) instead. This allows for a lot more flexibility
+and separation of concerns going forward!</p>
+</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.2.0-prerelease.1/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.2.0-prerelease.1</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.2.0-prerelease.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 14 2023 at 18:01 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>BREAKING</h3>
+<ul>
+<li><strong>make artifact autodetect configurable - <a href="https://github.com/Gankra" rel="noopener noreferrer">Gankra</a>/<a href="https://github.com/axodotdev/oranda/pull/527" rel="noopener noreferrer">pr527</a></strong></li>
+</ul>
+<h3>Features</h3>
+<ul>
+<li>
+<p><strong>Typescript syntax highlighting support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/525" rel="noopener noreferrer">pr525</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/513" rel="noopener noreferrer">i513</a></strong></p>
+</li>
+<li>
+<p><strong>Better logo positioning - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>/<a href="https://github.com/axodotdev/oranda/pull/524" rel="noopener noreferrer">pr524</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/519" rel="noopener noreferrer">i519</a></strong></p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Hacker theme highlight color - <a href="https://github.com/SaraVieira" rel="noopener noreferrer">SaraVieira</a>, <a href="https://github.com/axodotdev/oranda/pull/523" rel="noopener noreferrer">pr523</a>/<a href="https://github.com/axodotdev/oranda/issues/522" rel="noopener noreferrer">i522</a></strong></p>
+</li>
+<li>
+<p><strong>Package managers documentation - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/521" rel="noopener noreferrer">pr521</a>, <a href="https://github.com/tertsdiepraam" rel="noopener noreferrer">tertsdiepraam</a>/<a href="https://github.com/axodotdev/oranda/issues/520" rel="noopener noreferrer">i520</a></strong></p>
+</li>
+</ul>
+<h3>Maintenance</h3>
+<ul>
+<li><strong>Refactor into using minijinja templates instead of axohtml - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/526" rel="noopener noreferrer">pr526</a></strong></li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.3.0-prerelease.1/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.3.0-prerelease.1</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.1
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 25 2023 at 09:45 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.3.0-prerelease.2/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.3.0-prerelease.2</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.2
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 26 2023 at 17:32 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.3.0-prerelease.3/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.3.0-prerelease.3</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.3
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Jul 26 2023 at 18:51 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+<li>
+<p><strong>Show prerelease contents on changelog pages - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/[pr549]</strong></p>
+<p>This is a simple bug fix. Previously, we accidentally hid the body of a prerelease on its own separate changelog page
+(but mysteriously, it showed up on the main changelog page when prereleases were toggled!)</p>
+</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.3.0-prerelease.4/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.3.0-prerelease.4</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.4
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  1 2023 at 09:17 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/532" rel="noopener noreferrer">pr532</a>, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+<li>
+<p><strong>Basic CSS caching - <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/pull/551" rel="noopener noreferrer">pr551</a></strong></p>
+<p>In line with workspace support, oranda will now attempt to keep already downloaded versions of its CSS in-memory, which
+helps tremendously when you have a lot of workspace members all using the latest CSS version.</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+<li>
+<p><strong>Show prerelease contents on changelog pages - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/549" rel="noopener noreferrer">pr549</a></strong></p>
+<p>This is a simple bug fix. Previously, we accidentally hid the body of a prerelease on its own separate changelog page
+(but mysteriously, it showed up on the main changelog page when prereleases were toggled!)</p>
+</li>
+<li>
+<p><strong>Restrict parsed repo URLs to GitHub only - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/553" rel="noopener noreferrer">pr553</a></strong></p>
+<p>Right now, we only support GitHub repository URLs to get context from. This fixed an issue where technically, oranda
+would attempt to do this with GitLab URLs as well, which would cause unintended behavior.</p>
+</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/changelog/v0.3.0-prerelease.5/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Version 0.3.0-prerelease.5</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release pre-release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.3.0-prerelease.5
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  3 2023 at 17:45 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        <h3>Features</h3>
+<ul>
+<li>
+<p><strong>Workspace Support - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/many PRs, <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/issues/493" rel="noopener noreferrer">i493</a></strong></p>
+<p>You can now tell oranda to build multiple sites at once! By default, this will also generate a separate "root"
+page, providing an index into all projects defined within your workspace.</p>
+<p>Details TBD</p>
+</li>
+<li>
+<p><strong>Inlining CSS</strong> - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/565" rel="noopener noreferrer">pr565</a>, <a href="https://github.com/axodotdev/oranda/pull/566" rel="noopener noreferrer">pr566</a>, <a href="https://github.com/axodotdev/oranda/issues/554" rel="noopener noreferrer">i554</a></p>
+<p>oranda now uses a CSS version that's included in the binary it's shipped with! This means no more HTTP requests to GitHub
+to fetch a CSS version over and over. As a bonus, we removed the internal dependency on a Node.js toolchain to build
+the CSS in development, which should make hacking on oranda and its themes a lot easier!</p>
+</li>
+<li>
+<p><strong>Basic CSS caching - <a href="https://github.com/jamesmunns" rel="noopener noreferrer">jamesmunns</a>/<a href="https://github.com/axodotdev/oranda/pull/551" rel="noopener noreferrer">pr551</a></strong></p>
+<p>In line with workspace support, oranda will now attempt to keep already downloaded versions of its CSS in-memory, which
+helps tremendously when you have a lot of workspace members all using a custom CSS version.</p>
+</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>
+<p><strong>Display platforms alphabetically in install widget - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/544" rel="noopener noreferrer">pr544</a>, <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/issues/480" rel="noopener noreferrer">i480</a></strong></p>
+<p>Platforms are now sorted alphabetically in the install widget dropdown. This is an improvement over the
+previous unsorted state.</p>
+</li>
+<li>
+<p><strong>Show prerelease contents on changelog pages - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/549" rel="noopener noreferrer">pr549</a></strong></p>
+<p>This is a simple bug fix. Previously, we accidentally hid the body of a prerelease on its own separate changelog page
+(but mysteriously, it showed up on the main changelog page when prereleases were toggled!)</p>
+</li>
+<li>
+<p><strong>Restrict parsed repo URLs to GitHub only - <a href="https://github.com/Plecra" rel="noopener noreferrer">Plecra</a>/<a href="https://github.com/axodotdev/oranda/pull/553" rel="noopener noreferrer">pr553</a></strong></p>
+<p>Right now, we only support GitHub repository URLs to get context from. This fixed an issue where technically, oranda
+would attempt to do this with GitLab URLs as well, which would cause unintended behavior.</p>
+</li>
+<li>
+<p><strong>Support <code>git+https</code> URLs</strong> - <a href="https://github.com/shadows-withal" rel="noopener noreferrer">shadows-withal</a>/<a href="https://github.com/axodotdev/oranda/pull/563" rel="noopener noreferrer">pr563</a>, <a href="https://github.com/geelen" rel="noopener noreferrer">geelen</a>/<a href="https://github.com/axodotdev/oranda/issues/531" rel="noopener noreferrer">i531</a></p>
+<p>oranda now correctly handles <code>git+https://yourrepo</code> repository URLs, and is a lot more informative when it encounters
+one that it <em>can't</em> parse.</p>
+</li>
+</ul>
+
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+    </body>
+</html>
+================ public/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark axo">
+    <head>
+        <title>oranda</title>
+        
+            <meta property="og:url" content="https://opensource.axo.dev/oranda" />
+        
+        
+            <link rel="icon" href="/oranda/favicon.ico" />
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+            <meta name="description" content="🎁 generate beautiful landing pages for your projects" />
+            <meta property="og:description" content="🎁 generate beautiful landing pages for your projects" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda" />
+        
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta property="og:image" content="https://www.axo.dev/meta_small.jpeg" />
+        
+        
+            <meta property="og:image:alt" content="axo" />
+        
+        
+            <meta name="twitter:creator" content="@axodotdev" />
+            <meta name="twitter:site" content="@axodotdev" />
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/axodotdev/oranda">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/oranda/">Home</a></li>
+
+            
+
+            
+                <li><a href="/oranda/artifacts/">Install</a></li>
+            
+
+            
+                <li><a href="/oranda/book/">Docs</a></li>
+            
+
+            
+
+            
+                <li><a href="/oranda/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+
+    
+
+
+
+<div class="artifacts" data-tag="v0.2.0">
+    <div class="artifact-header target">
+        <h4>Install v0.2.0</h4>
+        
+            <div><small class="published-date">Published on Jul 19 2023 at 16:06 UTC</small></div>
+        
+
+        <ul class="arches">
+            
+                <li class="arch hidden" data-arch="aarch64-apple-darwin">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="aarch64-apple-darwin">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="8" data-triple="aarch64-apple-darwin">
+                                    cargo
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="aarch64-apple-darwin">
+                                    npm
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="3" data-triple="aarch64-apple-darwin">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="aarch64-apple-darwin" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/oranda/oranda-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="8" data-triple="aarch64-apple-darwin" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo install oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">locked</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">profile</span><span style="color:#89ddff;">=</span><span style="color:#82aaff;">dist</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo install oranda --locked --profile=dist">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="aarch64-apple-darwin" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npm install @axodotdev/oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">save-dev</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npm install @axodotdev/oranda --save-dev">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="3" data-triple="aarch64-apple-darwin" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">oranda-aarch64-apple-darwin.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-apple-darwin">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="x86_64-apple-darwin">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="8" data-triple="x86_64-apple-darwin">
+                                    cargo
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="x86_64-apple-darwin">
+                                    npm
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="4" data-triple="x86_64-apple-darwin">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="x86_64-apple-darwin" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/oranda/oranda-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="8" data-triple="x86_64-apple-darwin" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo install oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">locked</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">profile</span><span style="color:#89ddff;">=</span><span style="color:#82aaff;">dist</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo install oranda --locked --profile=dist">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="x86_64-apple-darwin" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npm install @axodotdev/oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">save-dev</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npm install @axodotdev/oranda --save-dev">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="4" data-triple="x86_64-apple-darwin" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">oranda-x86_64-apple-darwin.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-pc-windows-msvc">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="1" data-triple="x86_64-pc-windows-msvc">
+                                    powershell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="8" data-triple="x86_64-pc-windows-msvc">
+                                    cargo
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="x86_64-pc-windows-msvc">
+                                    npm
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="5" data-triple="x86_64-pc-windows-msvc">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="1" data-triple="x86_64-pc-windows-msvc" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/oranda/oranda-installer.ps1.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="8" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo install oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">locked</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">profile</span><span style="color:#89ddff;">=</span><span style="color:#82aaff;">dist</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo install oranda --locked --profile=dist">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npm install @axodotdev/oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">save-dev</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npm install @axodotdev/oranda --save-dev">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="5" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">oranda-x86_64-pc-windows-msvc.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+                <li class="arch hidden" data-arch="x86_64-unknown-linux-gnu">
+                    
+                        <ul class="tabs">
+                            
+                                
+                                
+                                <li class="install-tab" data-id="0" data-triple="x86_64-unknown-linux-gnu">
+                                    shell
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="8" data-triple="x86_64-unknown-linux-gnu">
+                                    cargo
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="7" data-triple="x86_64-unknown-linux-gnu">
+                                    npm
+                                </li>
+                            
+                                
+                                
+                                <li class="install-tab" data-id="6" data-triple="x86_64-unknown-linux-gnu">
+                                    tarball
+                                </li>
+                            
+                        </ul>
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="x86_64-unknown-linux-gnu" class="install-content">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+        
+        
+            
+        
+        <a class="button primary" href="/oranda/oranda-installer.sh.txt">Source</a>
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="8" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">cargo install oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">locked</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">profile</span><span style="color:#89ddff;">=</span><span style="color:#82aaff;">dist</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="cargo install oranda --locked --profile=dist">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="7" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+                                
+                                    
+                                    <div class="install-code-wrapper">
+    <pre style="background-color:#263238;">
+<span style="color:#82aaff;">npm install @axodotdev/oranda</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">save-dev</span></pre>
+
+    <button class="button copy-clipboard-button primary" data-copy="npm install @axodotdev/oranda --save-dev">
+        <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
+    </button>
+    
+    
+</div>
+                                
+
+                                
+                            </li>
+                        
+                            
+                            <li data-id="6" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">oranda-x86_64-unknown-linux-gnu.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+        </ul>
+    </div>
+
+    
+        <div class="no-autodetect hidden">
+            <span class="no-autodetect-details">We weren't able to detect your OS.</span>
+        </div>
+        <noscript>
+            <a href="/oranda/artifacts/">View all installation options</a>
+        </noscript>
+    
+    <div class="mac-switch hidden">This project doesn't offer Apple Silicon downloads, but you can run Intel macOS binaries via Rosetta 2.</div>
+
+    
+    
+    <div class="bottom-options ">
+        <a href="/oranda/artifacts/" class="backup-download primary">View all installation options</a>
+        
+            <div class="arch-select hidden">
+                <select id="install-arch-select">
+                    <option disabled="true" selected="true" value=""></option>
+                    
+                        <option value="x86_64-unknown-linux-gnu">Linux x64</option>
+                    
+                        <option value="aarch64-apple-darwin">macOS Apple Silicon</option>
+                    
+                        <option value="x86_64-apple-darwin">macOS Intel</option>
+                    
+                        <option value="x86_64-pc-windows-msvc">Windows x64</option>
+                    
+                </select>
+            </div>
+        
+    </div>
+</div>
+
+<a href="/oranda/artifacts/" class="button mobile-download primary">View all installation options</a>
+
+<div class="oranda-hide">
+<h1>oranda</h1>
+</div>
+<blockquote>
+<p>🎁 generate beautiful landing pages for your projects</p>
+</blockquote>
+<p><a href="https://crates.io/crates/oranda" rel="noopener noreferrer"><img src="https://img.shields.io/crates/v/oranda.svg" alt="crates.io"></a>
+<a href="https://github.com/axodotdev/oranda/actions/workflows/ci.yml" rel="noopener noreferrer"><img src="https://github.com/axodotdev/oranda/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+<a href="https://github.com/axodotdev/oranda/actions/workflows/release.yml" rel="noopener noreferrer"><img src="https://github.com/axodotdev/oranda/actions/workflows/release.yml/badge.svg" alt="release"></a>
+<a href="https://github.com/axodotdev/oranda/actions/workflows/web.yml" rel="noopener noreferrer"><img src="https://github.com/axodotdev/oranda/actions/workflows/web.yml/badge.svg?branch=main" alt="web"></a></p>
+<p><code>oranda</code> is an opinionated static-site generator that is designed for developers
+who are publishing projects and would like a website but don't want to build
+one from scratch.</p>
+<div class="oranda-hide">
+<p><code>oranda</code> uses <code>oranda</code> so you can checkout a live example <a href="https://axodotdev.github.io/oranda" rel="noopener noreferrer">here</a>!</p>
+<h2>Installation</h2>
+<p>To install <code>oranda</code>, please visit the <a href="https://axodotdev.github.io/oranda" rel="noopener noreferrer"><code>oranda</code> website</a>- which is generated by
+<code>oranda</code>!</p>
+</div>
+<h2>Quickstart</h2>
+<pre style="background-color:#263238;"><span style="font-style:italic;color:#546e7a;"># build your site
+</span><span style="color:#89ddff;">&gt;</span><span style="color:#82aaff;"> oranda build
+</span><span style="color:#eeffff;">
+</span><span style="font-style:italic;color:#546e7a;"># start a server to checkout a local version of your built site in a browser
+</span><span style="color:#89ddff;">&gt;</span><span style="color:#82aaff;"> oranda serve
+</span><span style="color:#eeffff;">
+</span><span style="font-style:italic;color:#546e7a;"># build your site and start a server that rebuilds on file changes
+</span><span style="color:#89ddff;">&gt;</span><span style="color:#82aaff;"> oranda dev
+</span></pre>
+
+<p>Here's an animated demo:</p>
+<p><img src="https://github.com/axodotdev/oranda/assets/6445316/439082a6-2caa-477e-93cc-1ff985d9bb21" alt="oranda demo gif"></p>
+<h2>Configuration</h2>
+<p>If you'd like to configure <code>oranda</code>, place an <code>oranda.json</code> file in the root of
+your project and fill it with the configuration you'd like. Check out the <a href="https://opensource.axo.dev/oranda/book/configuration.html" rel="noopener noreferrer">docs</a>
+to learn more about your configuration options!</p>
+<h2>Installers: integrating with <code>cargo-dist</code></h2>
+<p><code>oranda</code> is built to work alongside <a href="https://github.com/axodotdev/cargo-dist" rel="noopener noreferrer"><code>cargo-dist</code></a>, which is a tool that builds
+distributable artifacts for your Rust applications. To tell <code>oranda</code> you are
+using <code>cargo-dist</code> you can add this to your <code>oranda.json</code>:</p>
+<pre style="background-color:#263238;"><span style="color:#89ddff;">"</span><span style="color:#c3e88d;">artifacts</span><span style="color:#89ddff;">"</span><span style="color:#eeffff;">: </span><span style="color:#89ddff;">{
+</span><span style="color:#eeffff;">
+</span><span style="color:#eeffff;">    </span><span style="color:#c792ea;">"cargo_dist"</span><span style="color:#89ddff;">: </span><span style="color:#f78c6c;">true
+</span><span style="color:#89ddff;">}
+</span></pre>
+
+<p>This will link <code>oranda</code> and <code>cargo-dist</code> such that <code>oranda</code> can display your
+installers and downloadable artifacts on your page.</p>
+
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/axodotdev/oranda"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda, MIT OR Apache-2.0
+                </span>
+            </footer>
+        </div>
+
+        
+            <script defer="true" data-domain="opensource.axo.dev" src="https://plausible.io/js/script.js"></script>
+        
+        
+
+        
+
+    <script src="/oranda/artifacts.js"></script>
+
+
+    </body>
+</html>
+

--- a/tests/snapshots/gal_oranda_empty-public.snap
+++ b/tests/snapshots/gal_oranda_empty-public.snap
@@ -1,0 +1,188 @@
+---
+source: tests/gallery/oranda_impl.rs
+expression: "&snapshots"
+---
+================ public/artifacts/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark">
+    <head>
+        <title>oranda-empty-test</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda-empty-test" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/shadows-withal/oranda-empty-test">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda-empty-test</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/">Home</a></li>
+
+            
+
+            
+                <li><a href="/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <div class="package-managers-downloads">
+        
+    </div>
+    <div>
+        <h3>Downloads</h3>
+        <table class="artifacts-table">
+            <tbody>
+                <tr>
+                    <th>File</th>
+                    <th>Platform</th>
+                    
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/shadows-withal/oranda-empty-test"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda-empty-test
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+<script src="/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark">
+    <head>
+        <title>oranda-empty-test</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda-empty-test" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/shadows-withal/oranda-empty-test">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda-empty-test</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/">Home</a></li>
+
+            
+
+            
+                <li><a href="/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+
+<p>hey</p>
+
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/shadows-withal/oranda-empty-test"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda-empty-test
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+
+    <script src="/artifacts.js"></script>
+
+
+    </body>
+</html>
+

--- a/tests/snapshots/gal_oranda_inference-public.snap
+++ b/tests/snapshots/gal_oranda_inference-public.snap
@@ -1,0 +1,170 @@
+---
+source: tests/gallery/oranda_impl.rs
+expression: "&snapshots"
+---
+================ public/artifacts/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark">
+    <head>
+        <title>My Oranda Project</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="My Oranda Project" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">My Oranda Project</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/">Home</a></li>
+
+            
+
+            
+                <li><a href="/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <div class="package-managers-downloads">
+        
+    </div>
+    <div>
+        <h3>Downloads</h3>
+        <table class="artifacts-table">
+            <tbody>
+                <tr>
+                    <th>File</th>
+                    <th>Platform</th>
+                    
+                </tr>
+                
+            </tbody>
+        </table>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                <span>
+                    My Oranda Project
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+<script src="/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark">
+    <head>
+        <title>My Oranda Project</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="My Oranda Project" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">My Oranda Project</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/">Home</a></li>
+
+            
+
+            
+                <li><a href="/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+
+<p>add readme</p>
+
+
+                </main>
+            </div>
+
+            <footer>
+                
+                <span>
+                    My Oranda Project
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+
+    <script src="/artifacts.js"></script>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
How to build the gallery:

```
cargo test gal_
```

How to serve the gallery:

```
cd target/tmp
cargo run -- serve
```

* [x] add harness
* [x] add build-pass tests
* [x] add workspace build-pass test ("the gallery")
* [x] snaphot testing of public/
  * [x] implement (currently filtered to all files that end in .html)
  * [x] fix: stable ordering of platform html in install widget (i think the `select` is always sorted but the actual entries the select reveals aren't)
  * [x] fix: filter the name of oranda.css (`cargo test` and `cargo test --release` write different file names)
* [x] fix: prevent hanging of gal_workspace (tries to wait for all other tests to signal success, so hangs if any fail to build)
* [x] fix: make `cargo test` work without `--release` (need to make the runtime generate-css function remember where CARGO_MANIFEST_DIR is instead of just going relative to cwd, so that the resulting binary can be run in different dirs on the same system)
* [x] feat: add a way to do multiple variants of the same repo that works with `oranda-workspace.json` (cargo-dist can happily edit the same checkout over and over, but oranda-workspace wants each variant to exist at the same time, so I'll probably just add a variant of `run_test` that takes a custom id (checkout dir name) so that you can checkout the same repo multiple times)
* [x] fix: ??? some way to prevent new Github Releases adding new data to the tests and causing snapshots to invalidate?
* [ ] fix: ??? visually distinguish variant gallery entries (if you have multiple copies of cargo-dist, workspace-index.html makes no visual distinction between the two, you can only tell based on the url of the "website" link)