### PR TITLE
feat: add markdown docs to workspaces

### DIFF
--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -15,6 +15,8 @@ pub struct WorkspaceLayer {
     pub members: Option<Vec<WorkspaceMember>>,
     /// Whether to enable workspace autodetection
     pub auto: Option<bool>,
+    /// The path to additional documentation to render
+    pub docs_path: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, Hash, PartialEq, Eq)]
@@ -32,6 +34,7 @@ pub struct WorkspaceConfig {
     pub generate_index: bool,
     pub members: Vec<WorkspaceMember>,
     pub auto: bool,
+    pub docs_path: Option<String>,
 }
 
 impl Default for WorkspaceConfig {
@@ -41,6 +44,7 @@ impl Default for WorkspaceConfig {
             generate_index: true,
             members: Vec::new(),
             auto: false,
+            docs_path: None,
         }
     }
 }
@@ -53,10 +57,12 @@ impl ApplyLayer for WorkspaceConfig {
             members,
             generate_index,
             auto,
+            docs_path,
         } = layer;
         self.name.apply_opt(name);
         self.generate_index.apply_val(generate_index);
         self.members.apply_val(members);
         self.auto.apply_val(auto);
+        self.docs_path = docs_path
     }
 }

--- a/templates/workspace_index/index.html.j2
+++ b/templates/workspace_index/index.html.j2
@@ -1,6 +1,10 @@
 {% extends "workspace_index/layout.html" %}
 
 {% block content %}
+{% if page.docs_content %}
+    {{ page.docs_content|safe }}
+{% endif %}
+
 <ul class="index-grid">
     {% for member in page.members %}
         <li>

--- a/tests/integration_gallery/oranda_impl.rs
+++ b/tests/integration_gallery/oranda_impl.rs
@@ -15,7 +15,7 @@ use super::repo::{Repo, TestContext, TestContextLock, ToolsImpl};
 ///
 /// (RFC 3339 entry on utctime.net)
 const DEFAULT_DATA_CLAMP: &str = "2023-08-08T20:56:30+00:00";
-/// Set this at runtime to override DEFAULT_DATA_CLAMP           
+/// Set this at runtime to override DEFAULT_DATA_CLAMP
 const ENV_DATA_CLAMP: &str = "DEBUG_DATA_CLAMP_DATE";
 /// Set this at runtime to override STATIC_CARGO_DIST_BIN
 const ENV_RUNTIME_ORANDA_BIN: &str = "OVERRIDE_CARGO_BIN_EXE_oranda";
@@ -142,6 +142,7 @@ impl Tools {
                 generate_index: Some(true),
                 members: Some(vec![]),
                 auto: Some(false),
+                docs_path: None,
             }),
             _schema: None,
         };


### PR DESCRIPTION
This enables embedding markdown documents into the workspace landing page, similar to how the funding page works today.

Refs #564.