### PR TITLE
feat: add "preferred" member to workspaces

### DIFF
--- a/oranda-css/css/pages/workspace_index.css
+++ b/oranda-css/css/pages/workspace_index.css
@@ -23,3 +23,11 @@ ul.index-grid {
 .index-grid .content .index-logo {
     @apply relative flex-shrink-0 w-20 h-20;
 }
+
+.index-grid li.preferred {
+    @apply col-span-2;
+}
+
+.index-about h2 {
+    @apply mt-0;
+}

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -13,6 +13,8 @@ pub struct WorkspaceLayer {
     pub generate_index: Option<bool>,
     /// A list of workspace members
     pub members: Option<Vec<WorkspaceMember>>,
+    /// A list of members given priority in display
+    pub preferred_members: Option<Vec<String>>,
     /// Whether to enable workspace autodetection
     pub auto: Option<bool>,
     /// The path to additional documentation to render
@@ -33,6 +35,7 @@ pub struct WorkspaceConfig {
     pub name: Option<String>,
     pub generate_index: bool,
     pub members: Vec<WorkspaceMember>,
+    pub preferred_members: Vec<String>,
     pub auto: bool,
     pub docs_path: Option<String>,
 }
@@ -43,6 +46,7 @@ impl Default for WorkspaceConfig {
             name: Some("My Oranda Config".to_string()),
             generate_index: true,
             members: Vec::new(),
+            preferred_members: Vec::new(),
             auto: false,
             docs_path: None,
         }
@@ -55,6 +59,7 @@ impl ApplyLayer for WorkspaceConfig {
         let WorkspaceLayer {
             name,
             members,
+            preferred_members,
             generate_index,
             auto,
             docs_path,
@@ -62,6 +67,7 @@ impl ApplyLayer for WorkspaceConfig {
         self.name.apply_opt(name);
         self.generate_index.apply_val(generate_index);
         self.members.apply_val(members);
+        self.preferred_members.apply_val(preferred_members);
         self.auto.apply_val(auto);
         self.docs_path = docs_path
     }

--- a/templates/workspace_index/index.html.j2
+++ b/templates/workspace_index/index.html.j2
@@ -7,15 +7,25 @@
 
 <ul class="index-grid">
     {% for preferred in page.preferred_members %}
-    <li>
+        <li class="preferred">
+            <div class="content">
                 <div class="index-about">
                     <h2>{{ preferred.name }}</h2>
                     {% if preferred.description %}
                         <div class="index-description">{{ preferred.description }}</div>
                     {% endif %}
                 </div>
+            </div>
+            <div class="links">
+                <a href="{{ preferred.slug | generate_link(layout.path_prefix) }}">Website</a>
+                {% if preferred.repository %}
+                    <a href="{{ preferred.repository }}">Repository</a>
+                {% endif %}
+            </div>
+        </li>
     {% endfor %}
 </ul>
+
 <ul class="index-grid">
     {% for member in page.members %}
         <li>

--- a/templates/workspace_index/index.html.j2
+++ b/templates/workspace_index/index.html.j2
@@ -6,6 +6,17 @@
 {% endif %}
 
 <ul class="index-grid">
+    {% for preferred in page.preferred_members %}
+    <li>
+                <div class="index-about">
+                    <h2>{{ preferred.name }}</h2>
+                    {% if preferred.description %}
+                        <div class="index-description">{{ preferred.description }}</div>
+                    {% endif %}
+                </div>
+    {% endfor %}
+</ul>
+<ul class="index-grid">
     {% for member in page.members %}
         <li>
             <div class="content">

--- a/templates/workspace_index/index.html.j2
+++ b/templates/workspace_index/index.html.j2
@@ -1,10 +1,6 @@
 {% extends "workspace_index/layout.html" %}
 
 {% block content %}
-{% if page.docs_content %}
-    {{ page.docs_content|safe }}
-{% endif %}
-
 <ul class="index-grid">
     {% for preferred in page.preferred_members %}
         <li class="preferred">
@@ -25,6 +21,10 @@
         </li>
     {% endfor %}
 </ul>
+
+{% if page.docs_content %}
+    {{ page.docs_content|safe }}
+{% endif %}
 
 <ul class="index-grid">
     {% for member in page.members %}

--- a/tests/integration_gallery/oranda_impl.rs
+++ b/tests/integration_gallery/oranda_impl.rs
@@ -141,6 +141,7 @@ impl Tools {
                 name: Some("oranda gallery".to_owned()),
                 generate_index: Some(true),
                 members: Some(vec![]),
+                preferred_members: None,
                 auto: Some(false),
                 docs_path: None,
             }),


### PR DESCRIPTION
This adds a context of a "preferred" workspace member, akin to the preferred funding methods. These preferred members can be displayed distinctly from the other members in a more prominent position. The "preferred" field is an array of strings, like so:

```json
{
  "workspace": {
    "preferred_members": ["member"],
  }
}
```

This needs a design pass from an HTML/visual perspective - I've got the feature plumbed through from the config, but the display is just a placeholder at this point.

Refs #564.