### PR TITLE
feat: read from local changelog file, without cargo-dist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axoasset"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e85821647adf8212563f921ee791cbc75c0247d579a5ace3abcd6ab2cf87fe8d"
+dependencies = [
+ "camino",
+ "image",
+ "miette",
+ "mime",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml_edit",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "axocli"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,11 +223,11 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb23f8ea307ae166f1f8adaec070fc079500891b61515c3207bd22443220de43"
+checksum = "8779432e837cc1580e86ac5be2df7cf20b57e3c96f660da7c418ba17fa2300b6"
 dependencies = [
- "axoasset",
+ "axoasset 0.5.0",
  "camino",
  "clap",
  "console",
@@ -219,6 +237,7 @@ dependencies = [
  "node-semver",
  "oro-common",
  "oro-package-spec",
+ "parse-changelog",
  "pathdiff",
  "semver",
  "serde",
@@ -226,6 +245,7 @@ dependencies = [
  "thiserror",
  "toml_edit",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1500,6 +1520,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1634,6 +1655,12 @@ name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
+name = "lexopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"
@@ -2064,7 +2091,7 @@ dependencies = [
  "ammonia",
  "assert_cmd",
  "assert_fs",
- "axoasset",
+ "axoasset 0.4.0",
  "axocli",
  "axoproject",
  "axum",
@@ -2085,6 +2112,7 @@ dependencies = [
  "miette",
  "minifier",
  "minijinja",
+ "node-semver",
  "notify-debouncer-mini",
  "octolotl",
  "oranda-generate-css",
@@ -2092,6 +2120,7 @@ dependencies = [
  "reqwest",
  "schemars",
  "scraper",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2111,7 +2140,7 @@ dependencies = [
 name = "oranda-generate-css"
 version = "0.3.0-prerelease.5"
 dependencies = [
- "axoasset",
+ "axoasset 0.4.0",
  "camino",
  "directories",
  "miette",
@@ -2188,6 +2217,22 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "parse-changelog"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9325ebdf7f45ff257f87e1ab938263ec03abfc5495f02d5445224b56c055a7"
+dependencies = [
+ "anyhow",
+ "indexmap 2.0.0",
+ "lexopt",
+ "memchr",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["generate-css"]
 ammonia = "3"
 axoasset = { version = "0.4.0", features = ["json-serde", "toml-edit"] }
 axocli = "0.1.0"
-axoproject = { version = "0.4.2", default-features = false, features = ["cargo-projects", "npm-projects"] }
+axoproject = { version = "0.4.3", default-features = false, features = ["cargo-projects", "npm-projects"] }
 axum = "0.6.18"
 cargo-dist-schema = "=0.1.0-prerelease.4"
 chrono = "0.4.26"
@@ -30,6 +30,8 @@ lazy_static = "1.4.0"
 minifier = "0.2.2"
 octolotl = "0.1.1"
 reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
+semver = "1.0.17"
+node-semver = "2.1.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0.85" }
 serde_yaml = "0.9.21"

--- a/docs/src/configuration/changelog.md
+++ b/docs/src/configuration/changelog.md
@@ -1,18 +1,50 @@
 # Changelogs
 
-oranda supports reading your project's changelogs from GitHub releases. You can enable this by setting `components.changelog` to `true`:
+oranda supports reading your project's changelogs from GitHub releases and generating pages on your website from your release and release notes. This is automatically enabled if we can find
+a GitHub repository for your project, but if you don't want to use this, set the following option:
 
 ```json
 {
   "components": {
-    "changelog": true
+    "changelog": false
   }
 }
 ```
 
-This will result in a new "Changelog" page being generated. Changelogs are pulled directly from GitHub releases. If
-you're using the [`cargo-dist` integration](./artifacts.md), oranda will attempt to parse a `CHANGELOG.md`-like file for
-the changelogs instead.
+If you have a `CHANGELOG(.md)` file, oranda will attempt to parse your changelog
+contents for the respective versions, and embed them into the generates page(s). This file needs to be valid Markdown,
+and contain a valid header structure like this:
 
-> **NOTE:** We're working on getting changelog parsing from a `CHANGELOG.md` file as a default feature, without requiring
-  use of `cargo-dist`!
+```markdown
+# Changelog
+
+## 0.1.1 - 2023-04-05
+
+- Fixed things
+
+## 0.1.0 - 2023-04-02
+
+### New features
+
+- Fancy thingie
+- Other cool stuff
+
+### Fixes
+
+- Beep booping is now consistent
+```
+
+## Changelog settings
+
+The changelog option supports the following sub-settings:
+
+- [`read_changelog_file`](#read_changelog_file) - disable reading the changelog file
+
+### read_changelog_file
+
+> Added in version 0.3.0.
+
+Disables reading the changelog file, meaning that oranda will fall back to embedding the GitHub release body instead.
+Defaults to `true`.
+
+

--- a/src/config/components/changelog.rs
+++ b/src/config/components/changelog.rs
@@ -1,0 +1,38 @@
+use crate::config::{ApplyLayer, ApplyValExt};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Config for tweaking the changelog page generation
+#[derive(Debug, Clone)]
+pub struct ChangelogConfig {
+    /// Whether to attempt to read from the local changelog file
+    pub read_changelog_file: bool,
+}
+
+/// The config for generating a separate changelog page
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ChangelogLayer {
+    /// Whether we factor in the local `CHANGELOG.md` file, attempt to parse
+    /// it, and try and match version headings to release versions that we
+    /// detect.
+    pub read_changelog_file: Option<bool>,
+}
+
+impl Default for ChangelogConfig {
+    fn default() -> Self {
+        ChangelogConfig {
+            read_changelog_file: true,
+        }
+    }
+}
+
+impl ApplyLayer for ChangelogConfig {
+    type Layer = ChangelogLayer;
+    fn apply_layer(&mut self, layer: Self::Layer) {
+        // This is intentionally written slightly cumbersome to make you update this
+        let ChangelogLayer {
+            read_changelog_file,
+        } = layer;
+        self.read_changelog_file.apply_val(read_changelog_file);
+    }
+}

--- a/src/config/components/mod.rs
+++ b/src/config/components/mod.rs
@@ -2,14 +2,16 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 mod artifacts;
+mod changelog;
 mod funding;
 mod mdbooks;
 
+use crate::config::components::changelog::{ChangelogConfig, ChangelogLayer};
 pub use artifacts::{ArtifactsConfig, ArtifactsLayer, PackageManagersConfig, PackageManagersLayer};
 pub use funding::{FundingConfig, FundingLayer};
 pub use mdbooks::{MdBookConfig, MdBookLayer};
 
-use super::{ApplyBoolLayerExt, ApplyLayer, ApplyValExt, BoolOr};
+use super::{ApplyBoolLayerExt, ApplyLayer, BoolOr};
 
 /// Extra components (complete version)
 #[derive(Debug, Clone)]
@@ -17,7 +19,7 @@ pub struct ComponentConfig {
     /// Whether to enable the changelog page
     ///
     /// In the future this may become more complex, but for now this is it
-    pub changelog: bool,
+    pub changelog: Option<ChangelogConfig>,
     /// The config for using mdbook for a "docs" page
     ///
     /// This defaults to Some(Default) and is set to None
@@ -44,7 +46,7 @@ pub struct ComponentLayer {
     /// Whether to enable the changelog page
     ///
     /// In the future this may become more complex, but for now this is just a bool
-    pub changelog: Option<bool>,
+    pub changelog: Option<BoolOr<ChangelogLayer>>,
     /// The config for building and embedding an mdbook on your site
     ///
     /// The book will be linked as "docs" in the nav, and restyled to match
@@ -173,7 +175,7 @@ pub struct ComponentLayer {
 impl Default for ComponentConfig {
     fn default() -> Self {
         ComponentConfig {
-            changelog: false,
+            changelog: Some(ChangelogConfig::default()),
             mdbook: Some(MdBookConfig::default()),
             funding: Some(FundingConfig::default()),
             artifacts: Some(ArtifactsConfig::default()),
@@ -190,7 +192,7 @@ impl ApplyLayer for ComponentConfig {
             funding,
             artifacts,
         } = layer;
-        self.changelog.apply_val(changelog);
+        self.changelog.apply_bool_layer(changelog);
         self.mdbook.apply_bool_layer(mdbook);
         self.funding.apply_bool_layer(funding);
         self.artifacts.apply_bool_layer(artifacts);

--- a/src/data/release.rs
+++ b/src/data/release.rs
@@ -76,6 +76,11 @@ impl ReleaseSource {
             ReleaseSource::CurrentState(_src) => None,
         }
     }
+
+    /// Find out if we're working with a current state release
+    pub fn is_current_state(&self) -> bool {
+        matches!(self, ReleaseSource::CurrentState(_))
+    }
 }
 
 #[derive(Serialize, Clone, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -121,6 +121,9 @@ pub enum OrandaError {
         details: AxoassetError,
     },
 
+    #[error("Failed to parse package version {version}")]
+    PackageVersionParse { version: String },
+
     #[error("Unable to create a path to {path} from root path {root_path}.")]
     #[diagnostic(help(
         "It can help to have your workspace members in a subdirectory under your workspace root."
@@ -148,6 +151,15 @@ pub enum OrandaError {
         #[diagnostic_source]
         cause: axoproject::errors::AxoprojectError,
     },
+    #[error("Unable to parse changelog for {name} version {version}")]
+    #[diagnostic(help("Make sure that your changelog file lists the version in a header!"))]
+    ChangelogParseFailed {
+        name: String,
+        version: String,
+        #[source]
+        details: axoproject::errors::AxoprojectError,
+    },
+
     #[error("Failed to loading funding details at {path}")]
     #[diagnostic(severity = "warn")]
     FundingLoadFailed {

--- a/src/site/changelog.rs
+++ b/src/site/changelog.rs
@@ -1,3 +1,4 @@
+use axoproject::{Version, WorkspaceInfo, WorkspaceKind};
 use serde::Serialize;
 
 use crate::config::Config;
@@ -21,11 +22,24 @@ pub struct ChangelogRelease {
     pub body: String,
 }
 
-pub fn index_context(context: &Context, config: &Config) -> Result<ChangelogContext> {
+pub fn index_context(
+    context: &Context,
+    config: &Config,
+    project: Option<&WorkspaceInfo>,
+) -> Result<ChangelogContext> {
+    // Render an empty page if we're probably dealing with the "dummy" release generated as a
+    // fallback.
+    if context.releases.len() == 1 && context.releases[0].source.is_current_state() {
+        return Ok(ChangelogContext {
+            releases: Vec::new(),
+            has_prereleases: false,
+            os_script: javascript::build_os_script_path(&config.build.path_prefix),
+        });
+    }
     let releases = context
         .releases
         .iter()
-        .map(|release| single_context(release, config))
+        .map(|release| single_context(release, config, project))
         .collect();
     Ok(ChangelogContext {
         releases,
@@ -34,22 +48,79 @@ pub fn index_context(context: &Context, config: &Config) -> Result<ChangelogCont
     })
 }
 
-pub fn single_context(release: &Release, config: &Config) -> ChangelogRelease {
+pub fn single_context(
+    release: &Release,
+    config: &Config,
+    project: Option<&WorkspaceInfo>,
+) -> ChangelogRelease {
     ChangelogRelease {
         is_prerelease: release.source.is_prerelease(),
         version_tag: release.source.version_tag().to_string(),
         name: release.source.name().map(|s| s.to_string()),
         formatted_date: release.source.formatted_date(),
-        body: build_release_body(release, config).unwrap_or("".to_string()),
+        body: build_release_body(project, release, config).unwrap_or("".to_string()),
     }
 }
 
-fn build_release_body(release: &Release, config: &Config) -> Result<String> {
-    let contents = if let Some(manifest) = &release.manifest {
-        manifest.announcement_changelog.clone().unwrap_or_default()
+// Unwrap that we can't avoid without adding an extra if let block, since if let chains aren't stable
+#[allow(clippy::unnecessary_unwrap)]
+fn build_release_body(
+    project: Option<&WorkspaceInfo>,
+    release: &Release,
+    config: &Config,
+) -> Result<String> {
+    let contents = if config
+        .components
+        .changelog
+        .as_ref()
+        .is_some_and(|c| c.read_changelog_file)
+        && project.is_some()
+    {
+        let project = project.unwrap();
+        let version = release.source.version_tag();
+        let changelog = project
+            .changelog_for_version(&parse_version(version, project)?)
+            .map_err(|e| OrandaError::ChangelogParseFailed {
+                name: config.project.name.clone(),
+                version: version.to_owned(),
+                details: e,
+            })?;
+        if let Some(changelog) = changelog {
+            changelog.body
+        } else {
+            "".to_owned()
+        }
     } else {
         release.source.body().unwrap_or_default().to_owned()
     };
 
     markdown::to_html(&contents, &config.styles.syntax_theme)
+}
+
+/// Parses a version string into an axoproject-compatible version.
+fn parse_version(version_str: &str, project: &WorkspaceInfo) -> Result<Version> {
+    let version_str = if version_str.starts_with('v') {
+        version_str.strip_prefix('v').unwrap()
+    } else {
+        version_str
+    };
+
+    match project.kind {
+        WorkspaceKind::Rust => {
+            let version = semver::Version::parse(version_str).map_err(|_| {
+                OrandaError::PackageVersionParse {
+                    version: version_str.to_owned(),
+                }
+            })?;
+            Ok(Version::Cargo(version))
+        }
+        WorkspaceKind::Javascript => {
+            let version = node_semver::Version::parse(version_str).map_err(|_| {
+                OrandaError::PackageVersionParse {
+                    version: version_str.to_owned(),
+                }
+            })?;
+            Ok(Version::Npm(version))
+        }
+    }
 }

--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -94,7 +94,8 @@ impl LayoutContext {
         let changelog_link = &config
             .components
             .changelog
-            .then(|| link::generate(&config.build.path_prefix, "changelog/"));
+            .as_ref()
+            .map(|_| link::generate(&config.build.path_prefix, "changelog/"));
         let has_nav = additional_pages.is_some()
             || artifacts_link.is_some()
             || mdbook_link.is_some()

--- a/templates/changelog_index.html.j2
+++ b/templates/changelog_index.html.j2
@@ -15,6 +15,9 @@
                 </div>
             {% endif %}
 
+            {% if page.releases|length == 0 %}
+                <p>No releases yet!</p>
+            {% endif %}
             <ul>
                 {% for release in page.releases %}
                      <li class="{% if release.is_prerelease %}pre-release hidden{% endif %}">

--- a/tests/snapshots/gal_akaikatana-public.snap
+++ b/tests/snapshots/gal_akaikatana-public.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/gallery/oranda_impl.rs
+source: tests/integration_gallery/oranda_impl.rs
 expression: "&snapshots"
 ---
 ================ public/artifacts/index.html ================
@@ -53,6 +53,8 @@ expression: "&snapshots"
 
             
 
+            
+                <li><a href="/akaikatana-repack/changelog/">Changelog</a></li>
             
         </ul>
     </nav>
@@ -210,6 +212,244 @@ expression: "&snapshots"
 
     </body>
 </html>
+================ public/changelog/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="axo">
+    <head>
+        <title>akaikatana-repack</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="akaikatana-repack" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/akaikatana-repack/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/oranda-gallery/akaikatana-repack">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">akaikatana-repack</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/akaikatana-repack/">Home</a></li>
+
+            
+
+            
+                <li><a href="/akaikatana-repack/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/akaikatana-repack/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Releases</h1>
+    <div class="releases-wrapper">
+        <nav class="releases-nav">
+            
+
+            
+            <ul>
+                
+                     <li class="">
+                         <a href="v0.2.0/">v0.2.0</a>
+                     </li>
+                
+            </ul>
+        </nav>
+
+        <div class="releases-list">
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.2.0">
+        <a href="v0.2.0/">
+            
+                v0.2.0
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.2.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  8 2023 at 16:03 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+            
+        </div>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/oranda-gallery/akaikatana-repack"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    akaikatana-repack, GPL-2.0-or-later
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+<script src="/akaikatana-repack/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/changelog/v0.2.0/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="axo">
+    <head>
+        <title>akaikatana-repack</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="akaikatana-repack" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/akaikatana-repack/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/oranda-gallery/akaikatana-repack">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">akaikatana-repack</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/akaikatana-repack/">Home</a></li>
+
+            
+
+            
+                <li><a href="/akaikatana-repack/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/akaikatana-repack/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>v0.2.0</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.2.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  8 2023 at 16:03 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/oranda-gallery/akaikatana-repack"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    akaikatana-repack, GPL-2.0-or-later
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+    </body>
+</html>
 ================ public/index.html ================
 <!DOCTYPE html>
 <html lang="en" id="oranda" class="axo">
@@ -261,6 +501,8 @@ expression: "&snapshots"
 
             
 
+            
+                <li><a href="/akaikatana-repack/changelog/">Changelog</a></li>
             
         </ul>
     </nav>

--- a/tests/snapshots/gal_axolotlsay-public.snap
+++ b/tests/snapshots/gal_axolotlsay-public.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/gallery/oranda_impl.rs
+source: tests/integration_gallery/oranda_impl.rs
 expression: "&snapshots"
 ---
 ================ public/artifacts/index.html ================
@@ -374,6 +374,7 @@ expression: "&snapshots"
         <nav class="releases-nav">
             
 
+            
             <ul>
                 
                      <li class="">

--- a/tests/snapshots/gal_oranda-public.snap
+++ b/tests/snapshots/gal_oranda-public.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/gallery/oranda_impl.rs
+source: tests/integration_gallery/oranda_impl.rs
 expression: "&snapshots"
 ---
 ================ public/artifacts/index.html ================
@@ -464,6 +464,7 @@ expression: "&snapshots"
                 </div>
             
 
+            
             <ul>
                 
                      <li class="pre-release hidden">

--- a/tests/snapshots/gal_oranda_empty-public.snap
+++ b/tests/snapshots/gal_oranda_empty-public.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/gallery/oranda_impl.rs
+source: tests/integration_gallery/oranda_impl.rs
 expression: "&snapshots"
 ---
 ================ public/artifacts/index.html ================
@@ -54,6 +54,8 @@ expression: "&snapshots"
             
 
             
+                <li><a href="/changelog/">Changelog</a></li>
+            
         </ul>
     </nav>
 
@@ -76,6 +78,107 @@ expression: "&snapshots"
                 
             </tbody>
         </table>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/oranda-gallery/oranda-empty-test"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda-empty-test
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+<script src="/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/changelog/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark">
+    <head>
+        <title>oranda-empty-test</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda-empty-test" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/oranda-gallery/oranda-empty-test">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda-empty-test</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/">Home</a></li>
+
+            
+
+            
+                <li><a href="/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Releases</h1>
+    <div class="releases-wrapper">
+        <nav class="releases-nav">
+            
+
+            
+                <p>No releases yet!</p>
+            
+            <ul>
+                
+            </ul>
+        </nav>
+
+        <div class="releases-list">
+            
+        </div>
     </div>
 </div>
 
@@ -151,6 +254,8 @@ expression: "&snapshots"
 
             
 
+            
+                <li><a href="/changelog/">Changelog</a></li>
             
         </ul>
     </nav>

--- a/tests/snapshots/gal_oranda_inference-public.snap
+++ b/tests/snapshots/gal_oranda_inference-public.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/gallery/oranda_impl.rs
+source: tests/integration_gallery/oranda_impl.rs
 expression: "&snapshots"
 ---
 ================ public/artifacts/index.html ================
@@ -47,6 +47,8 @@ expression: "&snapshots"
             
 
             
+                <li><a href="/changelog/">Changelog</a></li>
+            
         </ul>
     </nav>
 
@@ -69,6 +71,98 @@ expression: "&snapshots"
                 
             </tbody>
         </table>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                <span>
+                    My Oranda Project
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+<script src="/artifacts.js"></script>
+
+    </body>
+</html>
+================ public/changelog/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark">
+    <head>
+        <title>My Oranda Project</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="My Oranda Project" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">My Oranda Project</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/">Home</a></li>
+
+            
+
+            
+                <li><a href="/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>Releases</h1>
+    <div class="releases-wrapper">
+        <nav class="releases-nav">
+            
+
+            
+                <p>No releases yet!</p>
+            
+            <ul>
+                
+            </ul>
+        </nav>
+
+        <div class="releases-list">
+            
+        </div>
     </div>
 </div>
 
@@ -135,6 +229,8 @@ expression: "&snapshots"
 
             
 
+            
+                <li><a href="/changelog/">Changelog</a></li>
             
         </ul>
     </nav>


### PR DESCRIPTION
Closes #324.

Parses changelogs from the local `CHANGELOG.md` file (or whichever file starts with `CHANGELOG` or `RELEASES`) to include in the changelog page, thanks to new axoproject functionality.

Adds a new `components.changelog.read_changelog_file` that's true by default, toggling this makes oranda fall back to using the GitHub release bodies. This doesn't break existing `changelog: true` configs, as we use `BoolOr` for this.

Unfortunately, I had to recompute the axoproject info an additional time, as we don't pass enough information around the `config` struct. I'm also not 100% happy with having to include `semver` and `node-semver` to inline version struct creation that axoproject's API wants, but this will do for now.