### PR TITLE
fix: only enable changelog if repo is set

### DIFF
--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 pub mod css;
 mod header;
 pub mod javascript;
+use crate::data::Context;
 use crate::site::layout::header::get_logo;
 use crate::site::{link, page};
 use javascript::analytics::Analytics;
@@ -42,7 +43,7 @@ pub struct AdditionalPageContext {
 }
 
 impl LayoutContext {
-    pub fn new(config: &Config) -> Result<Self> {
+    pub fn new(config: &Config, context: Option<&Context>) -> Result<Self> {
         let css_path =
             css::get_css_link(&config.build.path_prefix, &config.styles.oranda_css_version)?;
         let additional_pages = if config.build.additional_pages.is_empty() {
@@ -91,11 +92,15 @@ impl LayoutContext {
             .funding
             .as_ref()
             .map(|_| link::generate(&config.build.path_prefix, "funding/"));
-        let changelog_link = &config
-            .components
-            .changelog
-            .as_ref()
-            .map(|_| link::generate(&config.build.path_prefix, "changelog/"));
+        let changelog_link = if context.is_some() {
+            config
+                .components
+                .changelog
+                .as_ref()
+                .map(|_| link::generate(&config.build.path_prefix, "changelog/"))
+        } else {
+            None
+        };
         let has_nav = additional_pages.is_some()
             || artifacts_link.is_some()
             || mdbook_link.is_some()

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -115,7 +115,7 @@ impl Site {
             None
         };
 
-        let templates = Templates::new(config)?;
+        let templates = Templates::new(config, context.as_ref())?;
 
         let mut pages = vec![];
 
@@ -193,10 +193,11 @@ impl Site {
     }
 
     fn needs_context(config: &Config) -> Result<bool> {
-        Ok(config.components.artifacts_enabled()
-            || config.components.changelog.is_some()
-            || config.components.funding.is_some()
-            || Self::has_repo_and_releases(&config.project.repository)?)
+        Ok(config.project.repository.is_some()
+            && (config.components.artifacts_enabled()
+                || config.components.changelog.is_some()
+                || config.components.funding.is_some()
+                || Self::has_repo_and_releases(&config.project.repository)?))
     }
 
     fn has_repo_and_releases(repo_config: &Option<String>) -> Result<bool> {

--- a/src/site/templates.rs
+++ b/src/site/templates.rs
@@ -6,6 +6,7 @@
 //! can also use features such as imports, inheritance, extends, and so on.
 
 use crate::config::Config;
+use crate::data::Context;
 use crate::errors::Result;
 use crate::site::layout::LayoutContext;
 use crate::site::markdown::SyntaxTheme;
@@ -26,7 +27,7 @@ pub struct Templates<'a> {
 }
 
 impl<'a> Templates<'a> {
-    pub fn new(config: &Config) -> Result<Self> {
+    pub fn new(config: &Config, context: Option<&Context>) -> Result<Self> {
         let mut env = Environment::new();
         let mut files = HashMap::new();
         // These two `expects` should never happen in production, because all of these things are
@@ -43,7 +44,7 @@ impl<'a> Templates<'a> {
         env.add_filter("syntax_highlight", Self::syntax_highlight);
         // Use opt-in autoescape
         env.set_auto_escape_callback(|_| AutoEscape::None);
-        let layout = LayoutContext::new(config)?;
+        let layout = LayoutContext::new(config, context)?;
         Ok(Self { env, layout })
     }
 

--- a/tests/snapshots/gal_oranda_inference-public.snap
+++ b/tests/snapshots/gal_oranda_inference-public.snap
@@ -6,14 +6,14 @@ expression: "&snapshots"
 <!DOCTYPE html>
 <html lang="en" id="oranda" class="dark">
     <head>
-        <title>My Oranda Project</title>
+        <title>oranda-inference-test</title>
         
         
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         
         <meta property="og:type" content="website" />
-        <meta property="og:title" content="My Oranda Project" />
+        <meta property="og:title" content="oranda-inference-test" />
         
         
         
@@ -26,11 +26,18 @@ expression: "&snapshots"
         <div class="container">
             <div class="page-body">
                 
+                    <div class="repo_banner">
+                        <a href="https://github.com/oranda-gallery/oranda-inference-test">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
 
                 <main>
                     <header>
                         
-                        <h1 class="title">My Oranda Project</h1>
+                        <h1 class="title">oranda-inference-test</h1>
                         
     <nav class="nav">
         <ul>
@@ -58,6 +65,8 @@ expression: "&snapshots"
 <div>
     <div class="package-managers-downloads">
         
+            
+        
     </div>
     <div>
         <h3>Downloads</h3>
@@ -69,6 +78,20 @@ expression: "&snapshots"
                     
                 </tr>
                 
+                    
+                    
+                    <tr>
+                        <td><a href="https://github.com/oranda-gallery/oranda-inference-test/releases/download/v0.1.0/oranda-inference-test-x86_64-unknown-linux-gnu.tar.gz">oranda-inference-test-x86_64-unknown-linux-gnu.tar.gz</a></td>
+                        <td>
+                            
+                                
+                                    Linux x64
+                                
+                            
+                        </td>
+                        
+                    </tr>
+                
             </tbody>
         </table>
     </div>
@@ -79,8 +102,10 @@ expression: "&snapshots"
 
             <footer>
                 
+                    <a href="https://github.com/oranda-gallery/oranda-inference-test"><div class="github-icon" aria-hidden="true"></div></a>
+                
                 <span>
-                    My Oranda Project
+                    oranda-inference-test
                 </span>
             </footer>
         </div>
@@ -97,14 +122,14 @@ expression: "&snapshots"
 <!DOCTYPE html>
 <html lang="en" id="oranda" class="dark">
     <head>
-        <title>My Oranda Project</title>
+        <title>oranda-inference-test</title>
         
         
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         
         <meta property="og:type" content="website" />
-        <meta property="og:title" content="My Oranda Project" />
+        <meta property="og:title" content="oranda-inference-test" />
         
         
         
@@ -117,11 +142,18 @@ expression: "&snapshots"
         <div class="container">
             <div class="page-body">
                 
+                    <div class="repo_banner">
+                        <a href="https://github.com/oranda-gallery/oranda-inference-test">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
 
                 <main>
                     <header>
                         
-                        <h1 class="title">My Oranda Project</h1>
+                        <h1 class="title">oranda-inference-test</h1>
                         
     <nav class="nav">
         <ul>
@@ -153,14 +185,44 @@ expression: "&snapshots"
             
 
             
-                <p>No releases yet!</p>
-            
             <ul>
+                
+                     <li class="">
+                         <a href="v0.1.0/">v0.1.0</a>
+                     </li>
                 
             </ul>
         </nav>
 
         <div class="releases-list">
+            
+                
+                <section class="release ">
+    <h2 id="tag-v0.1.0">
+        <a href="v0.1.0/">
+            
+                v0.1.0
+            
+        </a>
+    </h2>
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  8 2023 at 16:27 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
             
         </div>
     </div>
@@ -171,8 +233,10 @@ expression: "&snapshots"
 
             <footer>
                 
+                    <a href="https://github.com/oranda-gallery/oranda-inference-test"><div class="github-icon" aria-hidden="true"></div></a>
+                
                 <span>
-                    My Oranda Project
+                    oranda-inference-test
                 </span>
             </footer>
         </div>
@@ -185,18 +249,18 @@ expression: "&snapshots"
 
     </body>
 </html>
-================ public/index.html ================
+================ public/changelog/v0.1.0/index.html ================
 <!DOCTYPE html>
 <html lang="en" id="oranda" class="dark">
     <head>
-        <title>My Oranda Project</title>
+        <title>oranda-inference-test</title>
         
         
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         
         <meta property="og:type" content="website" />
-        <meta property="og:title" content="My Oranda Project" />
+        <meta property="og:title" content="oranda-inference-test" />
         
         
         
@@ -209,11 +273,125 @@ expression: "&snapshots"
         <div class="container">
             <div class="page-body">
                 
+                    <div class="repo_banner">
+                        <a href="https://github.com/oranda-gallery/oranda-inference-test">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
 
                 <main>
                     <header>
                         
-                        <h1 class="title">My Oranda Project</h1>
+                        <h1 class="title">oranda-inference-test</h1>
+                        
+    <nav class="nav">
+        <ul>
+            <li><a href="/">Home</a></li>
+
+            
+
+            
+                <li><a href="/artifacts/">Install</a></li>
+            
+
+            
+
+            
+
+            
+                <li><a href="/changelog/">Changelog</a></li>
+            
+        </ul>
+    </nav>
+
+                    </header>
+
+                    
+<div>
+    <h1>v0.1.0</h1>
+    <div class="releases-body">
+        
+        
+        <section class="release ">
+    
+    <div class="release-info">
+        <span class="flex items-center gap-2">
+            <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'>
+    <path stroke-linecap='round' stroke-linejoin='round' d='M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z' />
+    <path stroke-linecap='round' stroke-linejoin='round' d='M6 6h.008v.008H6V6z' /></svg>
+            v0.1.0
+        </span>
+        <span class="flex items-center gap-2">
+            
+                <svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='currentColor' class='w-6 h-6'><path stroke-linecap='round' stroke-linejoin='round' d='M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5' /></svg>
+                Aug  8 2023 at 16:27 UTC
+            
+        </span>
+    </div>
+    <div class="release-body">
+        
+    </div>
+</section>
+    </div>
+</div>
+
+                </main>
+            </div>
+
+            <footer>
+                
+                    <a href="https://github.com/oranda-gallery/oranda-inference-test"><div class="github-icon" aria-hidden="true"></div></a>
+                
+                <span>
+                    oranda-inference-test
+                </span>
+            </footer>
+        </div>
+
+        
+        
+
+        
+    </body>
+</html>
+================ public/index.html ================
+<!DOCTYPE html>
+<html lang="en" id="oranda" class="dark">
+    <head>
+        <title>oranda-inference-test</title>
+        
+        
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="oranda-inference-test" />
+        
+        
+        
+        <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+        <link rel="stylesheet" href="/oranda.css" />
+        
+        
+    </head>
+    <body>
+        <div class="container">
+            <div class="page-body">
+                
+                    <div class="repo_banner">
+                        <a href="https://github.com/oranda-gallery/oranda-inference-test">
+                            <div class="github-icon" aria-hidden="true"></div>
+                            Check out our GitHub!
+                        </a>
+                    </div>
+                
+
+                <main>
+                    <header>
+                        
+                        <h1 class="title">oranda-inference-test</h1>
                         
     <nav class="nav">
         <ul>
@@ -239,6 +417,64 @@ expression: "&snapshots"
 
                     
 
+    
+
+
+
+<div class="artifacts" data-tag="v0.1.0">
+    <div class="artifact-header target">
+        <h4>Install v0.1.0</h4>
+        
+            <div><small class="published-date">Published on Aug  8 2023 at 16:27 UTC</small></div>
+        
+
+        <ul class="arches">
+            
+                <li class="arch" data-arch="x86_64-unknown-linux-gnu">
+                    
+
+                    <ul class="contents">
+                        
+                            
+                            <li data-id="0" data-triple="x86_64-unknown-linux-gnu" class="install-content">
+                                
+
+                                
+                                    
+                                     <div class="download-wrapper">
+                                         <a href="https://github.com/oranda-gallery/oranda-inference-test/releases/download/v0.1.0/oranda-inference-test-x86_64-unknown-linux-gnu.tar.gz">
+                                             <button class="button primary">
+                                                 <span>Download</span>
+                                                 <span class="button-subtitle">oranda-inference-test-x86_64-unknown-linux-gnu.tar.gz</span>
+                                             </button>
+                                         </a>
+                                     </div>
+                                
+                            </li>
+                        
+                    </ul>
+                </li>
+            
+        </ul>
+    </div>
+
+    
+    <div class="mac-switch hidden">This project doesn't offer Apple Silicon downloads, but you can run Intel macOS binaries via Rosetta 2.</div>
+
+    
+    
+    <div class="bottom-options one">
+        <a href="/artifacts/" class="backup-download primary">View all installation options</a>
+        
+            
+                <div class="arch-select">Platform: Linux x64</div>
+            
+        
+    </div>
+</div>
+
+<a href="/artifacts/" class="button mobile-download primary">View all installation options</a>
+
 <p>add readme</p>
 
 
@@ -247,8 +483,10 @@ expression: "&snapshots"
 
             <footer>
                 
+                    <a href="https://github.com/oranda-gallery/oranda-inference-test"><div class="github-icon" aria-hidden="true"></div></a>
+                
                 <span>
-                    My Oranda Project
+                    oranda-inference-test
                 </span>
             </footer>
         </div>


### PR DESCRIPTION
We don't want to show an empty changelog page if the repository isn't set (same goes for artifacts), so this PR fixes that.