### PR TITLE
chore: use our own global to emulate set_current_dir in gallery

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4
+indent_style = space

--- a/tests/integration_gallery/mod.rs
+++ b/tests/integration_gallery/mod.rs
@@ -8,7 +8,8 @@ mod repo;
 pub use errors::*;
 pub use oranda_impl::*;
 use std::collections::BTreeSet;
-use std::env::set_current_dir;
+
+use self::command::CommandInfo;
 
 /// Taken from cargo-insta to avoid copy-paste errors
 ///
@@ -89,7 +90,7 @@ fn gal_workspace() -> Result<()> {
         AXOLOTLSAY.run_test(|ctx| {
             num_iters += 1;
             // Go to the root
-            set_current_dir(ctx.tools.temp_root()).unwrap();
+            CommandInfo::set_working_dir(ctx.tools.temp_root());
 
             // Load the oranda-workspace.json and check if all tests are done
             let json = ctx.tools.load_oranda_workspace_json()?;

--- a/tests/integration_gallery/oranda_impl.rs
+++ b/tests/integration_gallery/oranda_impl.rs
@@ -96,6 +96,9 @@ pub struct Tools {
 impl Tools {
     fn new() -> Self {
         eprintln!("getting tools...");
+        CommandInfo::set_working_dir(
+            &Utf8PathBuf::from_path_buf(std::env::current_dir().unwrap()).unwrap(),
+        );
         let git = CommandInfo::new("git", None).expect("git isn't installed");
 
         // If OVERRIDE_* is set, prefer that over the version that cargo built for us,

--- a/tests/integration_gallery/repo.rs
+++ b/tests/integration_gallery/repo.rs
@@ -1,7 +1,6 @@
 use std::sync::{Mutex, MutexGuard};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use miette::IntoDiagnostic;
 
 use super::command::CommandInfo;
 use super::errors::Result;
@@ -113,7 +112,7 @@ where
 
         let ctx = TestContext { raw_ctx, tools };
         // Ensure we're in the right dir before running the test
-        std::env::set_current_dir(&ctx.working_dir).unwrap();
+        CommandInfo::set_working_dir(&ctx.working_dir);
 
         test(&ctx)
     }
@@ -189,14 +188,14 @@ where
     ) -> Result<()> {
         if repo_dir.exists() {
             eprintln!("repo already cloned, updating it...");
-            std::env::set_current_dir(repo_dir).into_diagnostic()?;
+            CommandInfo::set_working_dir(repo_dir);
             git.output_checked(|c| c.arg("remote").arg("set-url").arg("origin").arg(repo_url))?;
             git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_ref))?;
             git.output_checked(|c| c.arg("reset").arg("--hard").arg("FETCH_HEAD"))?;
         } else {
             eprintln!("fetching {repo_url}");
             axoasset::LocalAsset::create_dir_all(repo_dir)?;
-            std::env::set_current_dir(repo_dir).into_diagnostic()?;
+            CommandInfo::set_working_dir(repo_dir);
             git.output_checked(|c| c.arg("init"))?;
             git.output_checked(|c| c.arg("remote").arg("add").arg("origin").arg(repo_url))?;
             git.output_checked(|c| c.arg("fetch").arg("origin").arg(commit_ref))?;


### PR DESCRIPTION
This prevents races with other tests, as we never change the current_dir of the actual test process, only the processes that it spawns.