### PR TITLE
fix: use fixture repository for integration tests

### DIFF
--- a/tests/integration/fixtures/oranda_config.rs
+++ b/tests/integration/fixtures/oranda_config.rs
@@ -11,5 +11,14 @@ pub fn from_json(json: serde_json::Value, dir: &mut TempDir) -> Config {
     let mut config = Config::build(&Utf8PathBuf::from_path_buf(c.path().to_path_buf()).unwrap())
         .expect("Unable to generate config");
     config.build.dist_dir = dir.path().display().to_string();
+    // Override repository, except if it's non-standard
+    if config
+        .project
+        .repository
+        .as_ref()
+        .is_some_and(|repo| repo == "https://github.com/axodotdev/oranda")
+    {
+        config.project.repository = Some("https://github.com/oranda-gallery/oranda".to_string());
+    }
     config
 }

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -88,8 +88,7 @@ fn it_renders_changelog_with_release_content() {
     );
     let site = Site::build_single(&config, None).unwrap();
     let page = find_page(&site.pages, "changelog.html");
-    let html = selector_get_inner(&page.contents, "h2[id='tag-v0.0.1']~.release-body p");
-    assert_eq!(html, "Initial release.");
+    assert_selector_exists(&page.contents, "h2[id='tag-v0.2.0']~.release-body p>strong");
 }
 
 #[test]
@@ -165,7 +164,7 @@ fn creates_footer() {
     let page = find_page(&site.pages, "index.html");
     assert_selector_exists(
         &page.contents,
-        "footer>a[href='https://github.com/axodotdev/oranda']",
+        "footer>a[href='https://github.com/oranda-gallery/oranda']",
     );
     assert!(selector_get_inner(&page.contents, "footer span").contains("MIT OR Apache-2.0"));
 }


### PR DESCRIPTION
Don't use `axodotdev/oranda` for integration testing, which will break with time because it's an active repository. Instead, use `oranda-gallery/oranda`, which is identical, except it's basically frozen, which makes it a good fixture.