### PR TITLE
feat: improve homebrew handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,6 +2187,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "url-escape",
 ]
 
 [[package]]
@@ -3783,6 +3784,15 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "url-escape"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e0ce4d1246d075ca5abec4b41d33e87a6054d08e2366b63205665e950db218"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ include_dir = "0.7.3"
 slug = "0.1.4"
 oranda-generate-css = { version = "0.4.0-prerelease.1", path = "generate-css" }
 inquire = "0.6.2"
+url-escape = "0.1.1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/data/cargo_dist.rs
+++ b/src/data/cargo_dist.rs
@@ -55,7 +55,10 @@ impl ReleaseArtifacts {
                             // If there's an install-hint, assume this is something we're telling them to run
                             //
                             // Special hack: demote npm-packages, which cargo-dist presents kind of weird
-                            let file = if id.contains("npm-package") {
+                            // Also demote Homebrew packages
+                            let file = if id.contains("npm-package")
+                                || install_hint.contains("brew install")
+                            {
                                 preference = InstallerPreference::Custom;
                                 None
                             } else {
@@ -82,6 +85,8 @@ impl ReleaseArtifacts {
                             "powershell".to_owned()
                         } else if id.contains("npm-package") {
                             "npm".to_owned()
+                        } else if id.ends_with(".rb") {
+                            "homebrew".to_owned()
                         } else {
                             Utf8PathBuf::from(id).extension().unwrap_or(id).to_owned()
                         };

--- a/src/data/release.rs
+++ b/src/data/release.rs
@@ -153,19 +153,20 @@ impl Release {
         gh_release: &GithubRelease,
         repo: &GithubRepo,
     ) -> Result<Option<DistManifest>> {
-        let tag = &gh_release.tag_name;
+        let mut encoded_tag = String::new();
+        url_escape::encode_component_to_string(&gh_release.tag_name, &mut encoded_tag);
         if gh_release.has_dist_manifest() {
             let request = octolotl::request::ReleaseAsset::new(
                 &repo.owner,
                 &repo.name,
-                tag,
+                &encoded_tag,
                 cargo_dist::MANIFEST_FILENAME,
             );
             let response = octolotl::Request::send(&request, true)
                 .await?
                 .error_for_status()?;
 
-            Ok(Self::parse_response(response, tag).await?)
+            Ok(Self::parse_response(response, &gh_release.tag_name).await?)
         } else {
             Ok(None)
         }


### PR DESCRIPTION
Also escapes tag names now that `cargo-dist` supports more of them.