### PR TITLE
fix: choose less offensive mdbook highlight colors

### DIFF
--- a/oranda-css/mdbook-theme/oranda-themes/axo.css
+++ b/oranda-css/mdbook-theme/oranda-themes/axo.css
@@ -34,8 +34,8 @@
     --title-fg: var(--color-axo-pink);
     --subtitle-fg: var(--color-axo-purple);
     --border-color: var(--color-slate-700);
-    --main-font: Comfortaa,Comfortaa override,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-    --mono-font: ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
+    --main-font: Comfortaa, Comfortaa override, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+    --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
 
     --sidebar-bg: var(--bg);
     --sidebar-fg: var(--fg);
@@ -71,7 +71,7 @@
     --searchresults-header-fg: var(--title-fg);
     --searchresults-border-color: var(--border-color);
     --searchresults-li-bg: var(--well-bg);
-    --search-mark-bg: var(--well-bg);
+    --search-mark-bg: var(--color-axo-highlighter);
 }
 
 .oranda-light {
@@ -111,8 +111,8 @@
     --title-fg: var(--color-axo-pink);
     --subtitle-fg: var(--color-axo-purple);
     --border-color: var(--color-slate-700);
-    --main-font: Comfortaa,Comfortaa override,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;
-    --mono-font: ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
+    --main-font: Comfortaa, Comfortaa override, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+    --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
 
     --sidebar-bg: var(--bg);
     --sidebar-fg: var(--fg);
@@ -148,5 +148,5 @@
     --searchresults-header-fg: var(--title-fg);
     --searchresults-border-color: var(--border-color);
     --searchresults-li-bg: var(--well-bg);
-    --search-mark-bg: var(--well-bg);
+    --search-mark-bg: var(--color-axo-highlighter);
 }

--- a/oranda-css/mdbook-theme/oranda-themes/cupcake.css
+++ b/oranda-css/mdbook-theme/oranda-themes/cupcake.css
@@ -2,7 +2,7 @@
     /* 
       This part is just defining constants which fringe/oranda-css should probably
       be injecting into this file. For now, they're hardcoded.
-    */ 
+    */
     --color-cupcake-white: rgb(250, 247, 245);
     --color-cupcake-black: rgb(41, 19, 52);
     --color-cupcake-faded-black: rgba(41, 19, 52, 0.8);
@@ -58,5 +58,5 @@
     --searchresults-header-fg: var(--title-fg);
     --searchresults-border-color: var(--border-color);
     --searchresults-li-bg: var(--well-bg);
-    --search-mark-bg: var(--well-bg);
+    --search-mark-bg: var(--well-bg-highlight);
 }

--- a/oranda-css/mdbook-theme/oranda-themes/default.css
+++ b/oranda-css/mdbook-theme/oranda-themes/default.css
@@ -1,135 +1,135 @@
 .oranda-dark {
-  /* 
-      This part is just defining constants that are consistent
-      between both oranda themes, which oranda-css should probably
-      be injecting into this file. For now, they're hardcoded.
-    */
-  --dark-color: #141414;
-  --light-color: #ffffff;
-  --link-color: #0284c7;
-  --light-highlight-bg-color: #ededed;
-  --light-highlight-fg-color: #595959;
-  --dark-highlight-bg-color: #595959;
-  --dark-highlight-fg-color: #ededed;
-  --font-face: "Fira Sans", sans-serif;
+    /*
+        This part is just defining constants that are consistent
+        between both oranda themes, which oranda-css should probably
+        be injecting into this file. For now, they're hardcoded.
+      */
+    --dark-color: #141414;
+    --light-color: #ffffff;
+    --link-color: #0284c7;
+    --light-highlight-bg-color: #ededed;
+    --light-highlight-fg-color: #595959;
+    --dark-highlight-bg-color: #595959;
+    --dark-highlight-fg-color: #ededed;
+    --font-face: "Fira Sans", sans-serif;
 
-  /* 
-      Here we select which colors/fonts to use for this specific theme.
-      This first block calls a lot of the shots, most other definitions just
-      defer to these values.
-    */
-  --bg: var(--dark-color);
-  --fg: var(--light-color);
-  --well-bg: var(--dark-color);
-  --well-bg-highlight: var(--dark-color);
-  --title-fg: var(--light-color);
-  --subtitle-fg: var(--light-color);
-  --border-color: var(--dark-highlight-fg-color);
-  --main-font: var(--font-face);
-  --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    /*
+        Here we select which colors/fonts to use for this specific theme.
+        This first block calls a lot of the shots, most other definitions just
+        defer to these values.
+      */
+    --bg: var(--dark-color);
+    --fg: var(--light-color);
+    --well-bg: var(--dark-color);
+    --well-bg-highlight: var(--dark-color);
+    --title-fg: var(--light-color);
+    --subtitle-fg: var(--light-color);
+    --border-color: var(--dark-highlight-fg-color);
+    --main-font: var(--font-face);
+    --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     Liberation Mono, Courier New, monospace;
 
-  --sidebar-bg: var(--bg);
-  --sidebar-fg: var(--fg);
-  --sidebar-non-existant: var(--bg);
-  --sidebar-active: var(--link-color);
-  --sidebar-spacer: var(--border-color);
+    --sidebar-bg: var(--bg);
+    --sidebar-fg: var(--fg);
+    --sidebar-non-existant: var(--bg);
+    --sidebar-active: var(--link-color);
+    --sidebar-spacer: var(--border-color);
 
-  --scrollbar: default;
+    --scrollbar: default;
 
-  --icons: var(--light-color);
-  --icons-hover: var(--light-color);
+    --icons: var(--light-color);
+    --icons-hover: var(--light-color);
 
-  --links: var(--link-color);
-  --links-hover: var(--link-color);
+    --links: var(--link-color);
+    --links-hover: var(--link-color);
 
-  --inline-code-color: var(--link-color);
+    --inline-code-color: var(--link-color);
 
-  --theme-popup-bg: var(--well-bg);
-  --theme-popup-border: var(--border-color);
-  --theme-hover: var(--well-bg-highlight);
+    --theme-popup-bg: var(--well-bg);
+    --theme-popup-border: var(--border-color);
+    --theme-hover: var(--well-bg-highlight);
 
-  --quote-bg: var(--bg);
-  --quote-border: var(--border-color);
+    --quote-bg: var(--bg);
+    --quote-border: var(--border-color);
 
-  --table-border-color: var(--border-color);
-  --table-header-bg: var(--well-bg-highlight);
-  --table-alternate-bg: var(--well-bg);
+    --table-border-color: var(--border-color);
+    --table-header-bg: var(--well-bg-highlight);
+    --table-alternate-bg: var(--well-bg);
 
-  --searchbar-border-color: var(--border-color);
-  --searchbar-bg: var(--well-bg);
-  --searchbar-fg: var(--fg);
-  --searchbar-shadow-color: var(--border-color);
-  --searchresults-header-fg: var(--title-fg);
-  --searchresults-border-color: var(--border-color);
-  --searchresults-li-bg: var(--well-bg);
-  --search-mark-bg: var(--well-bg);
+    --searchbar-border-color: var(--border-color);
+    --searchbar-bg: var(--well-bg);
+    --searchbar-fg: var(--fg);
+    --searchbar-shadow-color: var(--border-color);
+    --searchresults-header-fg: var(--title-fg);
+    --searchresults-border-color: var(--border-color);
+    --searchresults-li-bg: var(--well-bg);
+    --search-mark-bg: var(--links);
 }
 
 .oranda-light {
-  /* 
-      This part is just defining constants that are consistent
-      between both oranda themes, which fringe/oranda-css should probably
-      be injecting into this file. For now, they're hardcoded.
-    */
-  --dark-color: #141414;
-  --light-color: #ffffff;
-  --link-color: #0284c7;
-  --light-highlight-bg-color: #ededed;
-  --light-highlight-fg-color: #595959;
-  --dark-highlight-bg-color: #595959;
-  --dark-highlight-fg-color: #ededed;
-  --font-face: "Fira Sans", sans-serif;
+    /*
+        This part is just defining constants that are consistent
+        between both oranda themes, which fringe/oranda-css should probably
+        be injecting into this file. For now, they're hardcoded.
+      */
+    --dark-color: #141414;
+    --light-color: #ffffff;
+    --link-color: #0284c7;
+    --light-highlight-bg-color: #ededed;
+    --light-highlight-fg-color: #595959;
+    --dark-highlight-bg-color: #595959;
+    --dark-highlight-fg-color: #ededed;
+    --font-face: "Fira Sans", sans-serif;
 
-  /* 
-      Here we select which colors/fonts to use for this specific theme.
-      This first block calls a lot of the shots, most other definitions just
-      defer to these values.
-    */
-  --bg: var(--light-color);
-  --fg: var(--dark-color);
-  --well-bg: var(--light-color);
-  --well-bg-highlight: var(--light-color);
-  --title-fg: var(--dark-color);
-  --subtitle-fg: var(--dark-color);
-  --border-color: var(--dark-color);
-  --main-font: var(--font-face);
-  --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    /*
+        Here we select which colors/fonts to use for this specific theme.
+        This first block calls a lot of the shots, most other definitions just
+        defer to these values.
+      */
+    --bg: var(--light-color);
+    --fg: var(--dark-color);
+    --well-bg: var(--light-color);
+    --well-bg-highlight: var(--light-color);
+    --title-fg: var(--dark-color);
+    --subtitle-fg: var(--dark-color);
+    --border-color: var(--dark-color);
+    --main-font: var(--font-face);
+    --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
     Liberation Mono, Courier New, monospace;
 
-  --sidebar-bg: var(--bg);
-  --sidebar-fg: var(--fg);
-  --sidebar-non-existant: var(--bg);
-  --sidebar-active: var(--link-color);
-  --sidebar-spacer: var(--border-color);
+    --sidebar-bg: var(--bg);
+    --sidebar-fg: var(--fg);
+    --sidebar-non-existant: var(--bg);
+    --sidebar-active: var(--link-color);
+    --sidebar-spacer: var(--border-color);
 
-  --scrollbar: default;
+    --scrollbar: default;
 
-  --icons: var(--dark-color);
-  --icons-hover: var(--dark-color);
+    --icons: var(--dark-color);
+    --icons-hover: var(--dark-color);
 
-  --links: var(--link-color);
-  --links-hover: var(--link-color);
+    --links: var(--link-color);
+    --links-hover: var(--link-color);
 
-  --inline-code-color: var(--link-color);
+    --inline-code-color: var(--link-color);
 
-  --theme-popup-bg: var(--well-bg);
-  --theme-popup-border: var(--border-color);
-  --theme-hover: var(--well-bg-highlight);
+    --theme-popup-bg: var(--well-bg);
+    --theme-popup-border: var(--border-color);
+    --theme-hover: var(--well-bg-highlight);
 
-  --quote-bg: var(--bg);
-  --quote-border: var(--border-color);
+    --quote-bg: var(--bg);
+    --quote-border: var(--border-color);
 
-  --table-border-color: var(--border-color);
-  --table-header-bg: var(--well-bg-highlight);
-  --table-alternate-bg: var(--well-bg);
+    --table-border-color: var(--border-color);
+    --table-header-bg: var(--well-bg-highlight);
+    --table-alternate-bg: var(--well-bg);
 
-  --searchbar-border-color: var(--border-color);
-  --searchbar-bg: var(--well-bg);
-  --searchbar-fg: var(--fg);
-  --searchbar-shadow-color: var(--border-color);
-  --searchresults-header-fg: var(--title-fg);
-  --searchresults-border-color: var(--border-color);
-  --searchresults-li-bg: var(--well-bg);
-  --search-mark-bg: var(--well-bg);
+    --searchbar-border-color: var(--border-color);
+    --searchbar-bg: var(--well-bg);
+    --searchbar-fg: var(--fg);
+    --searchbar-shadow-color: var(--border-color);
+    --searchresults-header-fg: var(--title-fg);
+    --searchresults-border-color: var(--border-color);
+    --searchresults-li-bg: var(--well-bg);
+    --search-mark-bg: var(--links);
 }

--- a/oranda-css/mdbook-theme/oranda-themes/hacker.css
+++ b/oranda-css/mdbook-theme/oranda-themes/hacker.css
@@ -2,7 +2,7 @@
     /* 
       This part is just defining constants which fringe/oranda-css should probably
       be injecting into this file. For now, they're hardcoded.
-    */ 
+    */
     --color-hacker-rouge: rgb(245, 112, 112);
     --color-hacker-orange: rgb(249, 115, 22);
     --color-hacker-green: rgb(32, 194, 14);
@@ -24,8 +24,8 @@
     --title-fg: var(--color-hacker-green);
     --subtitle-fg: var(--color-hacker-purple);
     --border-color: var(--color-hacker-orange);
-    --main-font: IBM Plex Mono,monospace;
-    --mono-font: IBM Plex Mono,monospace;
+    --main-font: IBM Plex Mono, monospace;
+    --mono-font: IBM Plex Mono, monospace;
 
     --sidebar-bg: var(--bg);
     --sidebar-fg: var(--color-hacker-orange);
@@ -61,5 +61,5 @@
     --searchresults-header-fg: var(--title-fg);
     --searchresults-border-color: var(--border-color);
     --searchresults-li-bg: var(--well-bg);
-    --search-mark-bg: var(--well-bg);
+    --search-mark-bg: var(--well-bg-highlight);
 }


### PR DESCRIPTION
Closes #578.

![image](https://github.com/axodotdev/oranda/assets/6445316/0edd3204-1b89-45cc-8307-c3f4390f2ce0)
![image](https://github.com/axodotdev/oranda/assets/6445316/db143794-3965-4f41-9bbc-101fbe3e7799)
![image](https://github.com/axodotdev/oranda/assets/6445316/87e88db4-7f57-47b9-9ef5-ed9c79654a8e)
![image](https://github.com/axodotdev/oranda/assets/6445316/fd6bf8f4-99e6-4283-877b-d321eaa4d79e)
![image](https://github.com/axodotdev/oranda/assets/6445316/6a200935-f1e5-475d-91d7-360e810250f9)
![image](https://github.com/axodotdev/oranda/assets/6445316/e10d7efb-6c49-4dde-96ae-73be02682910)
