### PR TITLE
chore: remove cargo install from front page

### DIFF
--- a/oranda.json
+++ b/oranda.json
@@ -23,10 +23,10 @@
     "artifacts": {
       "package_managers": {
         "preferred": {
-          "npm": "npm install @axodotdev/oranda --save-dev",
-          "cargo": "cargo install oranda --locked --profile=dist"
+          "npm": "npm install @axodotdev/oranda --save-dev"
         },
         "additional": {
+          "cargo": "cargo install oranda --locked --profile=dist",
           "npx": "npx @axodotdev/oranda",
           "binstall": "cargo binstall oranda",
           "nix-env": "nix-env -i oranda",


### PR DESCRIPTION
It's unintuitive, and as of the stable version, doesn't do what you expect it to do.