### PR TITLE
feat: relax file requirements, improve IO errors

### DIFF
--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -41,6 +41,8 @@ Since `oranda` is designed to work without configuration, the quickest start is 
 existing project! This will spawn a web server that serves your site, plus an extra process that watches for 
 changes in files relevant to `oranda`'s build process.
 
+> __NOTE__: Prior to version 0.5.0, oranda expects there to be a README.md file in your root directory!
+
 ## In a Cargo project
 
 `oranda` integrates with Cargo projects seamlessly. `oranda build` will pick up relevant

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -38,8 +38,8 @@ GLOBAL OPTIONS:
 ```
 
 Since `oranda` is designed to work without configuration, the quickest start is to just run `oranda dev` in an
-existing project with at least a `README.md` file! This will spawn a web server that serves your site, plus
-an extra process that watches for changes in files relevant to `oranda`'s build process.
+existing project! This will spawn a web server that serves your site, plus an extra process that watches for 
+changes in files relevant to `oranda`'s build process.
 
 ## In a Cargo project
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -212,7 +212,7 @@ pub enum OrandaError {
 
     #[error("Specified path `{path}` was not found on your filesystem!")]
     #[diagnostic(
-        help = "Make sure you're in the same directory where your oranda.json or README file is!"
+        help = "Make sure you specify your path relative to the oranda.json/manifest file/README file of your project!"
     )]
     PathDoesNotExist { path: String },
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -210,6 +210,12 @@ pub enum OrandaError {
     #[diagnostic(help = "You can manually specify path in your components.mdbook config")]
     MdBookConfigInvalid,
 
+    #[error("Specified path `{path}` was not found on your filesystem!")]
+    #[diagnostic(
+        help = "Make sure you're in the same directory where your oranda.json or README file is!"
+    )]
+    PathDoesNotExist { path: String },
+
     #[error("{0}")]
     Other(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod data;
 pub mod errors;
 pub mod formatter;
 pub mod generate;
+pub mod paths;
 pub mod site;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,71 @@
+use crate::errors;
+use crate::errors::OrandaError;
+use camino::{Utf8Path, Utf8PathBuf};
+
+/// Creates a workspace-safe relative path. Takes the following arguments:
+/// - The root path of the workspace (or single project)
+/// - An optional workspace member path
+/// - The path itself, usually extracted from the configuration
+/// Member path and the path itself can be relative or absolute .
+/// The function will attempt to lazily build the smallest possible absolute and canonicalized path,
+/// before diffing it with the root path to create a path that's always relative to the workspace root.
+///
+/// Some example scenarios:
+/// 1. root path = "/my/directory", member path = None, path = "myfile.md"
+///    Output = "myfile.md"
+/// 2. root path = "/my/directory", member path = "member", path = "myfile.md"
+///    Output = "member/myfile.md"
+/// 3. root path= "/my/directory", member path = "/my/directory/member", path = "../root.md"
+///    Output = "root.md"
+pub fn determine_path(
+    root_path: impl AsRef<Utf8Path>,
+    member_path: &Option<impl AsRef<Utf8Path>>,
+    path: impl AsRef<Utf8Path>,
+) -> errors::Result<Option<Utf8PathBuf>> {
+    let root_path = root_path.as_ref();
+    let member_path = member_path.as_ref().map(|p| p.as_ref());
+    let path = path.as_ref();
+    if path.is_absolute() {
+        // If absolute, return the path
+        return Ok(Some(path.to_owned()));
+    }
+
+    // If the member path exists and is absolute, construct `member_path/path`.
+    // If the member path exists and isn't absolute, construct `root_path/member_path/path`.
+    // If the member path doesn't exist, construct `root_path/path`.
+    let path_plus_member = if let Some(member_path) = member_path {
+        if member_path.is_absolute() {
+            let mut owned = Utf8PathBuf::new();
+            owned.push(member_path);
+            owned.push(path);
+            owned.canonicalize_utf8()
+        } else {
+            let mut owned = Utf8PathBuf::new();
+            owned.push(root_path);
+            owned.push(member_path);
+            owned.push(path);
+            owned.canonicalize_utf8()
+        }
+    } else {
+        let mut owned = Utf8PathBuf::new();
+        owned.push(root_path);
+        owned.push(path);
+        owned.canonicalize_utf8()
+    };
+
+    match path_plus_member {
+        Ok(path) => {
+            // Create a relative path from difference between root and created path.
+            Ok(Some(pathdiff::diff_utf8_paths(&path, root_path).ok_or(
+                OrandaError::PathdiffError {
+                    root_path: root_path.to_string(),
+                    path: path.to_string(),
+                },
+            )?))
+        }
+        Err(_) => {
+            // The path doesn't exist, return None
+            Ok(None)
+        }
+    }
+}

--- a/src/site/link.rs
+++ b/src/site/link.rs
@@ -1,5 +1,4 @@
-use crate::errors::{OrandaError, Result};
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 
 pub fn generate(path_prefix: &Option<String>, file_name: &str) -> String {
     // NOTE: intentionally no leading `/` here because it makes camino add a phantom `/` or `\`
@@ -28,72 +27,4 @@ pub fn generate(path_prefix: &Option<String>, file_name: &str) -> String {
     }
 
     output
-}
-
-/// Creates a workspace-safe relative path. Takes the following arguments:
-/// - The root path of the workspace (or single project)
-/// - An optional workspace member path
-/// - The path itself, usually extracted from the configuration
-/// Member path and the path itself can be relative or absolute .
-/// The function will attempt to lazily build the smallest possible absolute and canonicalized path,
-/// before diffing it with the root path to create a path that's always relative to the workspace root.
-///
-/// Some example scenarios:
-/// 1. root path = "/my/directory", member path = None, path = "myfile.md"
-///    Output = "myfile.md"
-/// 2. root path = "/my/directory", member path = "member", path = "myfile.md"
-///    Output = "member/myfile.md"
-/// 3. root path= "/my/directory", member path = "/my/directory/member", path = "../root.md"
-///    Output = "root.md"
-pub fn determine_path(
-    root_path: impl AsRef<Utf8Path>,
-    member_path: &Option<impl AsRef<Utf8Path>>,
-    path: impl AsRef<Utf8Path>,
-) -> Result<Utf8PathBuf> {
-    let root_path = root_path.as_ref();
-    let member_path = member_path.as_ref().map(|p| p.as_ref());
-    let path = path.as_ref();
-    if path.is_absolute() {
-        // If absolute, return the path
-        return Ok(path.to_owned());
-    }
-
-    // If the member path exists and is absolute, construct `member_path/path`.
-    // If the member path exists and isn't absolute, construct `root_path/member_path/path`.
-    // If the member path doesn't exist, construct `root_path/path`.
-    let path_plus_member = if let Some(member_path) = member_path {
-        if member_path.is_absolute() {
-            let mut owned = Utf8PathBuf::new();
-            owned.push(member_path);
-            owned.push(path);
-            owned.canonicalize_utf8()
-        } else {
-            let mut owned = Utf8PathBuf::new();
-            owned.push(root_path);
-            owned.push(member_path);
-            owned.push(path);
-            owned.canonicalize_utf8()
-        }
-    } else {
-        let mut owned = Utf8PathBuf::new();
-        owned.push(root_path);
-        owned.push(path);
-        owned.canonicalize_utf8()
-    };
-
-    match path_plus_member {
-        Ok(path) => {
-            // Create a relative path from difference between root and created path.
-            Ok(
-                pathdiff::diff_utf8_paths(&path, root_path).ok_or(OrandaError::PathdiffError {
-                    root_path: root_path.to_string(),
-                    path: path.to_string(),
-                })?,
-            )
-        }
-        Err(_) => {
-            // The path probably doesn't exist, return an empty path
-            Ok(Utf8PathBuf::new())
-        }
-    }
 }

--- a/src/site/mdbook.rs
+++ b/src/site/mdbook.rs
@@ -7,8 +7,8 @@ use crate::data::workspaces::WorkspaceData;
 use crate::errors::*;
 use crate::site::{oranda_theme::OrandaTheme, Site};
 
-use super::link::determine_path;
 use super::markdown::SyntaxTheme;
+use crate::paths::determine_path;
 
 // Files we're importing
 const THEME_GENERAL_CSS_PATH: &str = "css/general.css";
@@ -169,7 +169,13 @@ pub fn mdbook_dir(
         .as_ref()
         .expect("Had no mdbook.path, but config code didn't disable mdbook?");
     let path = determine_path(root_path, &member_path, book_path)?;
-    Ok(path)
+    if let Some(path) = path {
+        Ok(path)
+    } else {
+        Err(OrandaError::PathDoesNotExist {
+            path: book_path.clone(),
+        })
+    }
 }
 
 /// Gets the custom theme to set in an mdbook

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -158,14 +158,19 @@ impl Site {
             }
         }
 
-        pages.push(index.unwrap_or(Page::new_from_both(
-            &config.project.readme_path,
-            "index.html",
-            &templates,
-            "index.html",
-            context!(),
-            config,
-        )?));
+        let index = if let Some(index) = index {
+            index
+        } else {
+            Page::new_from_both(
+                &config.project.readme_path,
+                "index.html",
+                &templates,
+                "index.html",
+                context!(),
+                config,
+            )?
+        };
+        pages.push(index);
         Ok(Site {
             pages,
             workspace_data: None,
@@ -288,7 +293,7 @@ impl Site {
         let mut pages = vec![];
         for file_path in files.values() {
             if page::source::is_markdown(file_path) {
-                let additional_page = Page::new_from_markdown(file_path, templates, config)?;
+                let additional_page = Page::new_from_markdown(file_path, templates, config, true)?;
                 pages.push(additional_page)
             } else {
                 let msg = format!(

--- a/src/site/page/mod.rs
+++ b/src/site/page/mod.rs
@@ -4,7 +4,7 @@ use crate::config::Config;
 use crate::errors::*;
 use crate::site::markdown::{self, SyntaxTheme};
 
-use crate::site::link::determine_path;
+use crate::paths::determine_path;
 use crate::site::templates::Templates;
 use axoasset::SourceFile;
 use camino::Utf8PathBuf;
@@ -40,9 +40,23 @@ impl Page {
     /// Creates a new page by rendering a Markdown file into the "markdown page" template. Automatically
     /// determines the output path based on the path to the input Markdown file, diffing it with the
     /// basepath of the project.
-    pub fn new_from_markdown(path: &str, templates: &Templates, config: &Config) -> Result<Self> {
+    pub fn new_from_markdown(
+        path: &str,
+        templates: &Templates,
+        config: &Config,
+        fail_fast: bool,
+    ) -> Result<Self> {
         let body = Self::load_and_render_contents(path, &config.styles.syntax_theme)?;
-        let contents = templates.render_to_string("markdown_page.html", context!(body))?;
+        let contents = if let Some(body) = body {
+            templates.render_to_string("markdown_page.html", context!(body))?
+        } else {
+            if fail_fast {
+                return Err(OrandaError::PathDoesNotExist {
+                    path: path.to_string(),
+                });
+            }
+            templates.render_to_string("markdown_page.html", context!())?
+        };
         // Try diffing with the execution directory in case the user has provided an absolute-ish
         // path, in order to obtain the relative-to-dir path segment
         let relpath = if let Some(path) = pathdiff::diff_paths(path, std::env::current_dir()?) {
@@ -58,6 +72,9 @@ impl Page {
 
     /// Combines both above functions by rendering a Markdown file into an arbitrary template. The markdown
     /// content itself will be available under the "markdown_content" key in the template itself.
+    ///
+    /// If the provided path doesn't exist, it _will_ keep rendering the other content, and output
+    /// a warning to the console.
     pub fn new_from_both<T: Serialize>(
         path: &str,
         filename: &str,
@@ -67,6 +84,9 @@ impl Page {
         config: &Config,
     ) -> Result<Self> {
         let body = Self::load_and_render_contents(path, &config.styles.syntax_theme)?;
+        if body.is_none() {
+            tracing::warn!("{} could not be found on disk!", path);
+        }
         let template = templates.get(template_name)?;
         let context =
             context!(layout => templates.layout, page => context, markdown_content => body);
@@ -77,13 +97,20 @@ impl Page {
         })
     }
 
-    fn load_and_render_contents(source: &str, syntax_theme: &SyntaxTheme) -> Result<String> {
+    fn load_and_render_contents(
+        source: &str,
+        syntax_theme: &SyntaxTheme,
+    ) -> Result<Option<String>> {
         let src_path = Utf8PathBuf::from_path_buf(std::env::current_dir()?)
             .expect("Current directory is not UTF-8");
         let path = determine_path(src_path, &None::<Utf8PathBuf>, source)?;
-        let source = SourceFile::load_local(path)?;
-        let contents = source.contents();
-        markdown::to_html(contents, syntax_theme)
+        if let Some(path) = path {
+            let source = SourceFile::load_local(path)?;
+            let contents = source.contents();
+            Ok(Some(markdown::to_html(contents, syntax_theme)?))
+        } else {
+            Ok(None)
+        }
     }
 
     pub fn filename(source: &str) -> String {

--- a/src/site/workspace_index.rs
+++ b/src/site/workspace_index.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::data::workspaces::WorkspaceData;
-use crate::errors::Result;
-use crate::site::link::determine_path;
+use crate::errors::{OrandaError, Result};
+use crate::paths::determine_path;
 use crate::site::markdown::to_html;
 use axoasset::LocalAsset;
 use camino::Utf8PathBuf;
@@ -90,8 +90,12 @@ impl WorkspaceIndexContext {
             path.push(&member.slug);
             path.push(filename);
             Ok(path)
+        } else if let Some(path) = determine_path(root_path, &Some(&member.slug), logo_url)? {
+            Ok(path)
         } else {
-            determine_path(root_path, &Some(&member.slug), logo_url)
+            Err(OrandaError::PathDoesNotExist {
+                path: logo_url.clone(),
+            })
         }
     }
 }

--- a/templates/site/index.html.j2
+++ b/templates/site/index.html.j2
@@ -3,7 +3,9 @@
 {% if page.artifacts and page.artifacts.downloadable_files | length != 0 %}
     {% include "includes/artifacts_header.html" %}
 {% endif %}
-{{ markdown_content }}
+{% if markdown_content %}
+    {{ markdown_content }}
+{% endif %}
 {% endblock %}
 
 {% block os_script %}

--- a/templates/site/markdown_page.html.j2
+++ b/templates/site/markdown_page.html.j2
@@ -1,4 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-{{ page.body }}
+{% if page.body %}
+    {{ page.body }}
+{% endif %}
 {% endblock %}

--- a/tests/snapshots/gal_akaikatana-public.snap
+++ b/tests/snapshots/gal_akaikatana-public.snap
@@ -836,7 +836,8 @@ expression: "&snapshots"
 
 <a href="/akaikatana-repack/artifacts/" class="button mobile-download primary">View all installation options</a>
 
-<h2>Akai Katana music repacker</h2>
+
+    <h2>Akai Katana music repacker</h2>
 <p>This set of tools allows you to extract and replace the music from the <a href="https://store.steampowered.com/app/2076220/Akai_Katana_Shin/" rel="noopener noreferrer">Steam release of Akai Katana</a>. I was inspired to make it because I love the FM arranged soundtrack from the Nin2 Jump/Akai Katana CD, but there's no way to actually use it in game. If there won't be an official one, why not make my own?</p>
 <h3>Getting the tool</h3>
 <p>Prebuilt copies of the tool can be found in the <a href="https://github.com/mistydemeo/akaikatana-repack/releases" rel="noopener noreferrer">"releases" tab</a> in GitHub. You should be able to just download and run the ZIP file or tarball.</p>
@@ -855,6 +856,7 @@ expression: "&snapshots"
 <p>Contributions are always welcome! Please open issues if you run into any issues, and pull requests are always a big help.</p>
 <h3>License</h3>
 <p>GPL 2.0 or later.</p>
+
 
 
                 </main>

--- a/tests/snapshots/gal_axolotlsay-public.snap
+++ b/tests/snapshots/gal_axolotlsay-public.snap
@@ -1068,7 +1068,8 @@ expression: "&snapshots"
 
 <a href="/axolotlsay/artifacts/" class="button mobile-download primary">View all installation options</a>
 
-<h1>axolotlsay</h1>
+
+    <h1>axolotlsay</h1>
 <blockquote>
 <p>💬 a CLI for learning to distribute CLIs in rust</p>
 </blockquote>
@@ -1089,6 +1090,7 @@ expression: "&snapshots"
 <li>MIT license (<a href="LICENSE-MIT" rel="noopener noreferrer">LICENSE-MIT</a> or <a href="https://opensource.org/licenses/MIT" rel="noopener noreferrer">opensource.org/licenses/MIT</a>)</li>
 </ul>
 <p>at your option.</p>
+
 
 
                 </main>

--- a/tests/snapshots/gal_oranda-public.snap
+++ b/tests/snapshots/gal_oranda-public.snap
@@ -1612,7 +1612,8 @@ one that it <em>can't</em> parse.</p>
 
 <a href="/oranda/artifacts/" class="button mobile-download primary">View all installation options</a>
 
-<div class="oranda-hide">
+
+    <div class="oranda-hide">
 <h1>oranda</h1>
 </div>
 <blockquote>
@@ -1660,6 +1661,7 @@ using <code>cargo-dist</code> you can add this to your <code>oranda.json</code>:
 
 <p>This will link <code>oranda</code> and <code>cargo-dist</code> such that <code>oranda</code> can display your
 installers and downloadable artifacts on your page.</p>
+
 
 
                 </main>

--- a/tests/snapshots/gal_oranda_empty-public.snap
+++ b/tests/snapshots/gal_oranda_empty-public.snap
@@ -272,7 +272,9 @@ expression: "&snapshots"
 
                     
 
-<p>hey</p>
+
+    <p>hey</p>
+
 
 
                 </main>

--- a/tests/snapshots/gal_oranda_inference-public.snap
+++ b/tests/snapshots/gal_oranda_inference-public.snap
@@ -485,7 +485,9 @@ expression: "&snapshots"
 
 <a href="/artifacts/" class="button mobile-download primary">View all installation options</a>
 
-<p>add readme</p>
+
+    <p>add readme</p>
+
 
 
                 </main>


### PR DESCRIPTION
Behaviour changes:

- Readme file doesn't need to exist anymore, is now optional, with a warning being output
- oranda now hard errors when a hardcoded mdbook path can't be found
- local logo paths will now error when they're not found
- additional pages paths will also error when they're not found

TODO:

- [x] Add backticks around the path in the error message for readability
- [x] Update docs to mention that you don't need a readme circa 0.5.0