### PR TITLE
Package specific releases

### DIFF
--- a/docs/src/configuration/artifacts.md
+++ b/docs/src/configuration/artifacts.md
@@ -42,6 +42,13 @@ repository. It does this by trying to see if it can recognize any known target t
 it will recognize `mytool-aarch64-apple-darwin.tar.gz`. If you would like to completely disable this, set
 `components.artifacts` to `false` (we may offer a more fine-grained setting for this in the future).
 
+## Enabling matching a release to a specific package
+
+If you have multiple packages being produced by a workspace and need to match a release to a specific package, you can do
+so by setting `components.artifacts.match_package_names` to `true`. Upon enabling, while working to determine the latest
+release oranda will check if the release tag contains the name of the project being generated. If no match is found
+that particular release will be skipped.
+
 ## Adding package manager installation instructions
 
 You can add custom installation instructions for package managers or package manager-esque methods using the

--- a/docs/src/configuration/reference.md
+++ b/docs/src/configuration/reference.md
@@ -346,6 +346,15 @@ Enables/disables artifacts autodetection, even without `cargo-dist`. This is tur
 default, but if you provide GitHub release artifacts in a target-triple-like format, chances
 are that oranda can autodetect them, so it may be worth turning this on.
 
+### components.artifacts.match_package_names
+
+> Added in version 0.5.0.
+
+- Type: bool, Default: `false`
+
+Only uses release tags that contain the name of the project being generated. Useful in a workspace environment,
+where multiple published projects are stored in the same repository.
+
 ### components.mdbook (or components.md_book)
 
 > Added in version 0.1.0.

--- a/src/config/components/artifacts/mod.rs
+++ b/src/config/components/artifacts/mod.rs
@@ -38,6 +38,7 @@ enum ArtifactSystem {
 pub struct ArtifactsConfig {
     pub auto: bool,
     pub cargo_dist: bool,
+    pub package_specific_releases: bool,
     pub package_managers: PackageManagersConfig,
     pub hidden: Vec<String>,
 }
@@ -83,6 +84,13 @@ pub struct ArtifactsLayer {
     ///
     /// We default this to true if we find `[workspace.metadata.dist]` in your Cargo.toml
     pub cargo_dist: Option<bool>,
+    /// Whether to only show releases that contain the project name in their tag name
+    ///
+    /// This is useful if you have multiple projects in the same repo and want to only
+    /// show releases for that specific project on the generated project page.
+    ///
+    /// This defaults to false.
+    pub package_specific_releases: Option<bool>,
     /// Snippets saying how to install your project using various package-managers
     ///
     /// These are grouped into "preferred" and "additional"
@@ -130,6 +138,7 @@ impl Default for ArtifactsConfig {
         ArtifactsConfig {
             auto: false,
             cargo_dist: false,
+            package_specific_releases: false,
             package_managers: PackageManagersConfig::default(),
             hidden: vec![],
         }
@@ -142,12 +151,15 @@ impl ApplyLayer for ArtifactsConfig {
         let ArtifactsLayer {
             auto,
             cargo_dist,
+            package_specific_releases,
             package_managers,
             hidden,
         } = layer;
 
         self.auto.apply_val(auto);
         self.cargo_dist.apply_val(cargo_dist);
+        self.package_specific_releases
+            .apply_val(package_specific_releases);
         self.package_managers.apply_val_layer(package_managers);
         // In the future this might want to be `extend`
         self.hidden.apply_val(hidden);

--- a/src/config/components/artifacts/mod.rs
+++ b/src/config/components/artifacts/mod.rs
@@ -38,7 +38,7 @@ enum ArtifactSystem {
 pub struct ArtifactsConfig {
     pub auto: bool,
     pub cargo_dist: bool,
-    pub package_specific_releases: bool,
+    pub match_package_names: bool,
     pub package_managers: PackageManagersConfig,
     pub hidden: Vec<String>,
 }
@@ -90,7 +90,7 @@ pub struct ArtifactsLayer {
     /// show releases for that specific project on the generated project page.
     ///
     /// This defaults to false.
-    pub package_specific_releases: Option<bool>,
+    pub match_package_names: Option<bool>,
     /// Snippets saying how to install your project using various package-managers
     ///
     /// These are grouped into "preferred" and "additional"
@@ -138,7 +138,7 @@ impl Default for ArtifactsConfig {
         ArtifactsConfig {
             auto: false,
             cargo_dist: false,
-            package_specific_releases: false,
+            match_package_names: false,
             package_managers: PackageManagersConfig::default(),
             hidden: vec![],
         }
@@ -151,15 +151,14 @@ impl ApplyLayer for ArtifactsConfig {
         let ArtifactsLayer {
             auto,
             cargo_dist,
-            package_specific_releases,
+            match_package_names,
             package_managers,
             hidden,
         } = layer;
 
         self.auto.apply_val(auto);
         self.cargo_dist.apply_val(cargo_dist);
-        self.package_specific_releases
-            .apply_val(package_specific_releases);
+        self.match_package_names.apply_val(match_package_names);
         self.package_managers.apply_val_layer(package_managers);
         // In the future this might want to be `extend`
         self.hidden.apply_val(hidden);

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -127,10 +127,10 @@ impl Context {
         let mut latest_prerelease = None;
 
         for (idx, release) in releases.iter().enumerate() {
-            // If we're using package-specific releases, we want to skip any releases
+            // If we're matching package names to releases, we want to skip any releases
             // which tag name doesn't contain the project name
             if artifacts_config
-                .map(|a| a.package_specific_releases)
+                .map(|a| a.match_package_names)
                 .unwrap_or(false)
             {
                 if !release.source.version_tag().contains(&project_config.name) {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -132,10 +132,9 @@ impl Context {
             if artifacts_config
                 .map(|a| a.match_package_names)
                 .unwrap_or(false)
+                && !release.source.version_tag().contains(&project_config.name)
             {
-                if !release.source.version_tag().contains(&project_config.name) {
-                    continue;
-                }
+                continue;
             }
 
             // Make note of whether anything has artifacts


### PR DESCRIPTION
This adds a new optional field to the artifacts config `package_specific_releases` which will default to false. When false things will work as they currently do, when true an additional check is enabled in `Context::with_releases` that will skip the release should the version tag not contain the project name.

This also modifies `Context::with_releases` to require a reference to ProjectConfig as an argument in order to perform the check against the project name.