### PR TITLE
added additional_css to workspace index

### DIFF
--- a/src/site/layout/mod.rs
+++ b/src/site/layout/mod.rs
@@ -143,6 +143,7 @@ impl LayoutContext {
             project_name: workspace_config.workspace.name.clone().unwrap_or_default(),
             theme: workspace_config.styles.theme.as_css_classes(),
             oranda_css_path: css_path,
+            has_additional_css: !workspace_config.styles.additional_css.is_empty(),
             path_prefix: workspace_config.build.path_prefix.clone(),
             ..Default::default()
         })

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -84,6 +84,10 @@ impl Site {
             context,
         )?;
         let mut dist = Utf8PathBuf::from(&workspace_config.build.dist_dir);
+        let additional_css = &workspace_config.styles.additional_css;
+        if !additional_css.is_empty() {
+            css::write_additional_css(additional_css, &dist)?;
+        }
         dist.push("index.html");
         LocalAsset::write_new_all(&page.contents, dist)?;
         Ok(())

--- a/templates/site/workspace_index/layout.html.j2
+++ b/templates/site/workspace_index/layout.html.j2
@@ -5,6 +5,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="{{ layout.oranda_css_path }}" />
+    {% if layout.has_additional_css %}
+        <link rel="stylesheet" href="{{ "custom.css" | generate_link(layout.path_prefix) }}" />
+    {% endif %}
+    {% block head %}{% endblock %}
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
This checks for additional_css in the workspace config and if present will build the css asset and adds it to the workspace index page allowing for theme override. I've provided an example below with resulting screenshots from testing.

oranda-workspace.json
```json
"styles": {
  "theme": "axodark",
  "additional_css": ["./.assets/styles/oranda.css"]
}
```

oranda.css:
```css
html.axo {
    /* Our theme's own colors */
    --highlight-color: rgb(89, 75, 170) !important;
    --axo-orange-color: #594BAA !important;
    --axo-pink-color: #988ECC !important;
}
```

Before:
<img width="1056" alt="workspace-index-before" src="https://github.com/axodotdev/oranda/assets/612378/b5ced4bd-672e-4eff-9d8d-53b80c718ae1">

After:
<img width="1056" alt="workspace-index-after" src="https://github.com/axodotdev/oranda/assets/612378/21572ca3-c856-41c3-b1a2-73e24f02d016">
