### PR TITLE
sets color on divs in chapter list items with filter

### DIFF
--- a/oranda-css/mdbook-theme/css/chrome.css
+++ b/oranda-css/mdbook-theme/css/chrome.css
@@ -462,6 +462,11 @@ ul#searchresults span.teaser em {
     color: var(--sidebar-fg);
 }
 
+.chapter li.chapter-item div {
+    color: var(--sidebar-fg);
+    filter: brightness(60%);
+}
+
 .chapter li a:hover {
     color: var(--sidebar-active);
 }


### PR DESCRIPTION
Adds:

```css
.chapter li.chapter-item div {
    color: var(--sidebar-fg);
    filter: brightness(60%);
}
```

to `oranda-css/mdbook-theme/css/chrome.css`

Fixes #654 because currently the div in the list item is inheriting from:

```css
.chapter li {
    display: flex;
    color: var(--sidebar-non-existant);
}
```

Produces:
<img width="186" alt="Screenshot 2023-10-05 at 3 22 57 PM" src="https://github.com/axodotdev/oranda/assets/612378/8b3aba66-115c-4ba7-9f79-9d22bfffd504">
