### PR TITLE
Add app name to label

### DIFF
--- a/src/data/cargo_dist.rs
+++ b/src/data/cargo_dist.rs
@@ -1,4 +1,6 @@
 use camino::Utf8PathBuf;
+use std::fmt::Write;
+
 pub use cargo_dist_schema::{ArtifactKind, DistManifest};
 
 use super::artifacts::{
@@ -25,7 +27,7 @@ impl ReleaseArtifacts {
             }
 
             for (id, artifact) in manifest.artifacts_for_release(app) {
-                let label;
+                let mut label;
                 let method;
                 let preference;
                 let file = artifact.name.as_ref().and_then(|n| self.file_idx(n));
@@ -97,6 +99,11 @@ impl ReleaseArtifacts {
                         continue;
                     }
                 };
+
+                if manifest.releases.len() > 1 {
+                    let _ = write!(label, "<br /><i style=\"font-size: small;\">({})</i>", app.app_name);
+                }
+
                 let targets = preference_to_targets(artifact.target_triples.clone(), preference);
                 let installer = Installer {
                     label,


### PR DESCRIPTION
Closes #665 

This is just a small proof-of-concept. To display the names, it just checks if there are more than 1 releases inside the `cargo-dist` metadata.  
If there is, it adds them in a smaller font to the next line.

![image](https://github.com/axodotdev/oranda/assets/50245791/8b660156-907d-4b11-b520-f2ce60e2a2eb)

This iteration still uses inline styles and some HTML inside the `write!` call which is not really *optimal*, I feel like.  
But I just opened this draft PR to showcase how it *could* look like.
