### PR TITLE
fix: prevent mdbook from recursing infinitely

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -145,6 +145,13 @@ pub enum OrandaError {
         #[source]
         details: mdbook::errors::Error,
     },
+
+    #[error("Can't build mdbook because book output directory {dest_path} is under book source directory {src_path}")]
+    #[diagnostic(help(
+        "Make sure that your book source does not contain your book output directory, as that will lead to infinite recursion. Change either the `src` setting or the `build_dir` setting in your book.toml."
+    ))]
+    MdbookBuildRecursive { src_path: String, dest_path: String },
+
     #[error("We found a potential {kind} project at {manifest_path} but there was an issue")]
     #[diagnostic(severity = "warn")]
     BrokenProject {


### PR DESCRIPTION
Fixes #669. New error:

![image](https://github.com/axodotdev/oranda/assets/6445316/3c57110e-943f-4db1-a990-759ce5db4ae3)

Note: This only works when either both paths are absolute or both paths are relative. I consider mixing absolute and relative paths in the same config file a user error (on top of it being really hard to handle correctly, canonicalizing is a mess).