### PR TITLE
fix: don't respect cargo-dist's install hints for curl-sh exprs

### DIFF
--- a/src/data/cargo_dist.rs
+++ b/src/data/cargo_dist.rs
@@ -61,11 +61,14 @@ impl ReleaseArtifacts {
                             {
                                 preference = InstallerPreference::Custom;
                                 None
+                            } else if id.ends_with(".sh") || id.ends_with(".ps1") {
+                                // We have more info to do a better job than cargo-dist on
+                                // `curl | sh` exprs, inference will handle this for us!
+                                continue;
                             } else {
                                 preference = InstallerPreference::Script;
                                 file
                             };
-
                             method = InstallMethod::Run {
                                 file,
                                 run_hint: install_hint.clone(),

--- a/tests/snapshots/gal_akaikatana-public.snap
+++ b/tests/snapshots/gal_akaikatana-public.snap
@@ -73,9 +73,9 @@ expression: "&snapshots"
             <h3>powershell</h3>
             <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+<span style="color:#82aaff;">irm https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex">
+  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -96,9 +96,9 @@ expression: "&snapshots"
             <h3>shell</h3>
             <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -215,7 +215,7 @@ expression: "&snapshots"
   </body>
 </html>
 ================ public/artifacts.json ================
-{"format_version":"CENSORED","tag":"v0.2.0","formatted_date":"Aug  8 2023 at 16:03 UTC","platforms_with_downloads":[{"target":["aarch64-apple-darwin"],"display_name":"macOS Apple Silicon","installers":[0,2]},{"target":["x86_64-apple-darwin"],"display_name":"macOS Intel","installers":[0,3]},{"target":["x86_64-pc-windows-msvc"],"display_name":"Windows x64","installers":[1,4]},{"target":["x86_64-unknown-linux-gnu"],"display_name":"Linux x64","installers":[0,5]}],"downloadable_files":[[0,{"name":"akaikatana-repack-aarch64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},["macOS Apple Silicon"]],[3,{"name":"akaikatana-repack-x86_64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},["macOS Intel"]],[4,{"name":"akaikatana-repack-x86_64-pc-windows-msvc.zip","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-pc-windows-msvc.zip","view_path":null,"checksum_file":null},["Windows x64"]],[5,{"name":"akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","view_path":null,"checksum_file":null},["Linux x64"]]],"release":{"artifacts":{"files":[{"name":"akaikatana-repack-aarch64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},{"name":"akaikatana-repack-installer.ps1","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1","view_path":"akaikatana-repack-installer.ps1.txt","checksum_file":null},{"name":"akaikatana-repack-installer.sh","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh","view_path":"akaikatana-repack-installer.sh.txt","checksum_file":null},{"name":"akaikatana-repack-x86_64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},{"name":"akaikatana-repack-x86_64-pc-windows-msvc.zip","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-pc-windows-msvc.zip","view_path":null,"checksum_file":null},{"name":"akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","view_path":null,"checksum_file":null},{"name":"dist-manifest.json","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/dist-manifest.json","view_path":null,"checksum_file":null}],"installers":[{"label":"shell","description":"Install prebuilt binaries via shell script","app_name":null,"method":{"type":"Run","file":2,"run_hint":"curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh"}},{"label":"powershell","description":"Install prebuilt binaries via powershell script","app_name":null,"method":{"type":"Run","file":1,"run_hint":"irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex"}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":0}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":3}},{"label":"zip","description":"","app_name":null,"method":{"type":"Download","file":4}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":5}}],"targets":{"aarch64-apple-darwin":[0,2],"x86_64-apple-darwin":[0,3],"x86_64-pc-windows-msvc":[1,4],"x86_64-unknown-linux-gnu":[0,5]}}},"os_script":"/akaikatana-repack/artifacts.js","has_checksum_files":false}
+{"format_version":"CENSORED","tag":"v0.2.0","formatted_date":"Aug  8 2023 at 16:03 UTC","platforms_with_downloads":[{"target":["aarch64-apple-darwin"],"display_name":"macOS Apple Silicon","installers":[5,0]},{"target":["x86_64-apple-darwin"],"display_name":"macOS Intel","installers":[5,1]},{"target":["x86_64-pc-windows-msvc"],"display_name":"Windows x64","installers":[4,2]},{"target":["x86_64-unknown-linux-gnu"],"display_name":"Linux x64","installers":[5,3]}],"downloadable_files":[[0,{"name":"akaikatana-repack-aarch64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},["macOS Apple Silicon"]],[3,{"name":"akaikatana-repack-x86_64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},["macOS Intel"]],[4,{"name":"akaikatana-repack-x86_64-pc-windows-msvc.zip","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-pc-windows-msvc.zip","view_path":null,"checksum_file":null},["Windows x64"]],[5,{"name":"akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","view_path":null,"checksum_file":null},["Linux x64"]]],"release":{"artifacts":{"files":[{"name":"akaikatana-repack-aarch64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-aarch64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},{"name":"akaikatana-repack-installer.ps1","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1","view_path":"akaikatana-repack-installer.ps1.txt","checksum_file":null},{"name":"akaikatana-repack-installer.sh","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh","view_path":"akaikatana-repack-installer.sh.txt","checksum_file":null},{"name":"akaikatana-repack-x86_64-apple-darwin.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-apple-darwin.tar.xz","view_path":null,"checksum_file":null},{"name":"akaikatana-repack-x86_64-pc-windows-msvc.zip","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-pc-windows-msvc.zip","view_path":null,"checksum_file":null},{"name":"akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-x86_64-unknown-linux-gnu.tar.xz","view_path":null,"checksum_file":null},{"name":"dist-manifest.json","download_url":"https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/dist-manifest.json","view_path":null,"checksum_file":null}],"installers":[{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":0}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":3}},{"label":"zip","description":"","app_name":null,"method":{"type":"Download","file":4}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":5}},{"label":"powershell","description":"","app_name":null,"method":{"type":"Run","file":1,"run_hint":"irm https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex"}},{"label":"shell","description":"","app_name":null,"method":{"type":"Run","file":2,"run_hint":"curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh"}}],"targets":{"aarch64-apple-darwin":[5,0],"aarch64-pc-windows-msvc":[4],"aarch64-unknown-linux-gnu":[5],"aarch64-unknown-linux-musl":[5],"i686-apple-darwin":[5],"i686-pc-windows-msvc":[4],"i686-unknown-linux-gnu":[5],"i686-unknown-linux-musl":[5],"x86_64-apple-darwin":[5,1],"x86_64-pc-windows-msvc":[4,2],"x86_64-unknown-linux-gnu":[5,3],"x86_64-unknown-linux-musl":[5]}}},"os_script":"/akaikatana-repack/artifacts.js","has_checksum_files":false}
 ================ public/changelog/index.html ================
 <!DOCTYPE html>
 <html lang="en" id="oranda" class="axo">
@@ -548,7 +548,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="5" data-triple="aarch64-apple-darwin">
                   shell
 
                   
@@ -556,7 +556,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="2" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="0" data-triple="aarch64-apple-darwin">
                   tarball
 
                   
@@ -568,14 +568,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="aarch64-apple-darwin" class="install-content">
+              <li data-id="5" data-triple="aarch64-apple-darwin" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -593,7 +593,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="2" data-triple="aarch64-apple-darwin" class="install-content hidden">
+              <li data-id="0" data-triple="aarch64-apple-darwin" class="install-content hidden">
                 
 
                 
@@ -618,7 +618,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="5" data-triple="x86_64-apple-darwin">
                   shell
 
                   
@@ -626,7 +626,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="3" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="1" data-triple="x86_64-apple-darwin">
                   tarball
 
                   
@@ -638,14 +638,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="x86_64-apple-darwin" class="install-content">
+              <li data-id="5" data-triple="x86_64-apple-darwin" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -663,7 +663,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="3" data-triple="x86_64-apple-darwin" class="install-content hidden">
+              <li data-id="1" data-triple="x86_64-apple-darwin" class="install-content hidden">
                 
 
                 
@@ -688,7 +688,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="1" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="4" data-triple="x86_64-pc-windows-msvc">
                   powershell
 
                   
@@ -696,7 +696,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="4" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="2" data-triple="x86_64-pc-windows-msvc">
                   zip
 
                   
@@ -708,14 +708,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="1" data-triple="x86_64-pc-windows-msvc" class="install-content">
+              <li data-id="4" data-triple="x86_64-pc-windows-msvc" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+<span style="color:#82aaff;">irm https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex">
+  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.ps1 | iex">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -733,7 +733,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="4" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+              <li data-id="2" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
                 
 
                 
@@ -758,7 +758,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="5" data-triple="x86_64-unknown-linux-gnu">
                   shell
 
                   
@@ -766,7 +766,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="5" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="3" data-triple="x86_64-unknown-linux-gnu">
                   tarball
 
                   
@@ -778,14 +778,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="x86_64-unknown-linux-gnu" class="install-content">
+              <li data-id="5" data-triple="x86_64-unknown-linux-gnu" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/mistydemeo/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/akaikatana-repack/releases/download/v0.2.0/akaikatana-repack-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -803,7 +803,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="5" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+              <li data-id="3" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
                 
 
                 

--- a/tests/snapshots/gal_axolotlsay-public.snap
+++ b/tests/snapshots/gal_axolotlsay-public.snap
@@ -152,9 +152,9 @@ expression: "&snapshots"
             <h3>powershell</h3>
             <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+<span style="color:#82aaff;">irm https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex">
+  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -175,9 +175,9 @@ expression: "&snapshots"
             <h3>shell</h3>
             <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -296,7 +296,7 @@ expression: "&snapshots"
   </body>
 </html>
 ================ public/artifacts.json ================
-{"format_version":"CENSORED","tag":"v0.1.0","formatted_date":"Aug  8 2023 at 16:07 UTC","platforms_with_downloads":[{"target":["aarch64-apple-darwin"],"display_name":"macOS Apple Silicon","installers":[0,7,3]},{"target":["x86_64-apple-darwin"],"display_name":"macOS Intel","installers":[0,7,4]},{"target":["x86_64-pc-windows-msvc"],"display_name":"Windows x64","installers":[1,7,5]},{"target":["x86_64-unknown-linux-gnu"],"display_name":"Linux x64","installers":[0,7,6]}],"downloadable_files":[[0,{"name":"axolotlsay-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},["macOS Apple Silicon"]],[4,{"name":"axolotlsay-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},["macOS Intel"]],[5,{"name":"axolotlsay-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":null},["Windows x64"]],[6,{"name":"axolotlsay-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":null},["Linux x64"]]],"release":{"artifacts":{"files":[{"name":"axolotlsay-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-installer.ps1","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1","view_path":"axolotlsay-installer.ps1.txt","checksum_file":null},{"name":"axolotlsay-installer.sh","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh","view_path":"axolotlsay-installer.sh.txt","checksum_file":null},{"name":"axolotlsay-npm-package.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-npm-package.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":null},{"name":"dist-manifest.json","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/dist-manifest.json","view_path":null,"checksum_file":null}],"installers":[{"label":"shell","description":"Install prebuilt binaries via shell script","app_name":null,"method":{"type":"Run","file":2,"run_hint":"curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh"}},{"label":"powershell","description":"Install prebuilt binaries via powershell script","app_name":null,"method":{"type":"Run","file":1,"run_hint":"irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex"}},{"label":"npm","description":"Install prebuilt binaries into your npm project","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npm install @axodotdev/axolotlsay@0.1.0"}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":0}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":4}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":5}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":6}},{"label":"npx","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npx @axodotdev/axolotlsay"}},{"label":"crates.io","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo install axolotlsay --locked --profile=dist"}},{"label":"binstall","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo binstall axolotlsay"}}],"targets":{"aarch64-apple-darwin":[0,7,3],"aarch64-pc-windows-msvc":[7],"aarch64-unknown-linux-gnu":[7],"aarch64-unknown-linux-musl":[7],"i686-apple-darwin":[7],"i686-pc-windows-msvc":[7],"i686-unknown-linux-gnu":[7],"i686-unknown-linux-musl":[7],"x86_64-apple-darwin":[0,7,4],"x86_64-pc-windows-msvc":[1,7,5],"x86_64-unknown-linux-gnu":[0,7,6],"x86_64-unknown-linux-musl":[7]}}},"os_script":"/axolotlsay/artifacts.js","has_checksum_files":false}
+{"format_version":"CENSORED","tag":"v0.1.0","formatted_date":"Aug  8 2023 at 16:07 UTC","platforms_with_downloads":[{"target":["aarch64-apple-darwin"],"display_name":"macOS Apple Silicon","installers":[9,5,1]},{"target":["x86_64-apple-darwin"],"display_name":"macOS Intel","installers":[9,5,2]},{"target":["x86_64-pc-windows-msvc"],"display_name":"Windows x64","installers":[8,5,3]},{"target":["x86_64-unknown-linux-gnu"],"display_name":"Linux x64","installers":[9,5,4]}],"downloadable_files":[[0,{"name":"axolotlsay-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},["macOS Apple Silicon"]],[4,{"name":"axolotlsay-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},["macOS Intel"]],[5,{"name":"axolotlsay-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":null},["Windows x64"]],[6,{"name":"axolotlsay-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":null},["Linux x64"]]],"release":{"artifacts":{"files":[{"name":"axolotlsay-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-installer.ps1","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1","view_path":"axolotlsay-installer.ps1.txt","checksum_file":null},{"name":"axolotlsay-installer.sh","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh","view_path":"axolotlsay-installer.sh.txt","checksum_file":null},{"name":"axolotlsay-npm-package.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-npm-package.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":null},{"name":"axolotlsay-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":null},{"name":"dist-manifest.json","download_url":"https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/dist-manifest.json","view_path":null,"checksum_file":null}],"installers":[{"label":"npm","description":"Install prebuilt binaries into your npm project","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npm install @axodotdev/axolotlsay@0.1.0"}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":0}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":4}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":5}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":6}},{"label":"npx","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npx @axodotdev/axolotlsay"}},{"label":"crates.io","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo install axolotlsay --locked --profile=dist"}},{"label":"binstall","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo binstall axolotlsay"}},{"label":"powershell","description":"","app_name":null,"method":{"type":"Run","file":1,"run_hint":"irm https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex"}},{"label":"shell","description":"","app_name":null,"method":{"type":"Run","file":2,"run_hint":"curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh"}}],"targets":{"aarch64-apple-darwin":[9,5,1],"aarch64-pc-windows-msvc":[8,5],"aarch64-unknown-linux-gnu":[9,5],"aarch64-unknown-linux-musl":[9,5],"i686-apple-darwin":[9,5],"i686-pc-windows-msvc":[8,5],"i686-unknown-linux-gnu":[9,5],"i686-unknown-linux-musl":[9,5],"x86_64-apple-darwin":[9,5,2],"x86_64-pc-windows-msvc":[8,5,3],"x86_64-unknown-linux-gnu":[9,5,4],"x86_64-unknown-linux-musl":[9,5]}}},"os_script":"/axolotlsay/artifacts.js","has_checksum_files":false}
 ================ public/changelog/index.html ================
 <!DOCTYPE html>
 <html lang="en" id="oranda" class="dark axo">
@@ -680,7 +680,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="9" data-triple="aarch64-apple-darwin">
                   shell
 
                   
@@ -688,7 +688,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="5" data-triple="aarch64-apple-darwin">
                   npx
 
                   
@@ -696,7 +696,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="3" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="1" data-triple="aarch64-apple-darwin">
                   tarball
 
                   
@@ -708,14 +708,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="aarch64-apple-darwin" class="install-content">
+              <li data-id="9" data-triple="aarch64-apple-darwin" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -733,7 +733,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="7" data-triple="aarch64-apple-darwin" class="install-content hidden">
+              <li data-id="5" data-triple="aarch64-apple-darwin" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -752,7 +752,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="3" data-triple="aarch64-apple-darwin" class="install-content hidden">
+              <li data-id="1" data-triple="aarch64-apple-darwin" class="install-content hidden">
                 
 
                 
@@ -777,7 +777,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="9" data-triple="x86_64-apple-darwin">
                   shell
 
                   
@@ -785,7 +785,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="5" data-triple="x86_64-apple-darwin">
                   npx
 
                   
@@ -793,7 +793,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="4" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="2" data-triple="x86_64-apple-darwin">
                   tarball
 
                   
@@ -805,14 +805,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="x86_64-apple-darwin" class="install-content">
+              <li data-id="9" data-triple="x86_64-apple-darwin" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -830,7 +830,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="7" data-triple="x86_64-apple-darwin" class="install-content hidden">
+              <li data-id="5" data-triple="x86_64-apple-darwin" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -849,7 +849,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="4" data-triple="x86_64-apple-darwin" class="install-content hidden">
+              <li data-id="2" data-triple="x86_64-apple-darwin" class="install-content hidden">
                 
 
                 
@@ -874,7 +874,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="1" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="8" data-triple="x86_64-pc-windows-msvc">
                   powershell
 
                   
@@ -882,7 +882,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="5" data-triple="x86_64-pc-windows-msvc">
                   npx
 
                   
@@ -890,7 +890,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="5" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="3" data-triple="x86_64-pc-windows-msvc">
                   tarball
 
                   
@@ -902,14 +902,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="1" data-triple="x86_64-pc-windows-msvc" class="install-content">
+              <li data-id="8" data-triple="x86_64-pc-windows-msvc" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+<span style="color:#82aaff;">irm https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex">
+  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.ps1 | iex">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -927,7 +927,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="7" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+              <li data-id="5" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -946,7 +946,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="5" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+              <li data-id="3" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
                 
 
                 
@@ -971,7 +971,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="9" data-triple="x86_64-unknown-linux-gnu">
                   shell
 
                   
@@ -979,7 +979,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="5" data-triple="x86_64-unknown-linux-gnu">
                   npx
 
                   
@@ -987,7 +987,7 @@ expression: "&snapshots"
               
                 
                 
-                <li class="install-tab" data-id="6" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="4" data-triple="x86_64-unknown-linux-gnu">
                   tarball
 
                   
@@ -999,14 +999,14 @@ expression: "&snapshots"
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="x86_64-unknown-linux-gnu" class="install-content">
+              <li data-id="9" data-triple="x86_64-unknown-linux-gnu" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/axolotlsay/releases/download/v0.1.0/axolotlsay-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -1024,7 +1024,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="7" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+              <li data-id="5" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1043,7 +1043,7 @@ expression: "&snapshots"
               </li>
             
               
-              <li data-id="6" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+              <li data-id="4" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
                 
 
                 

--- a/tests/snapshots/gal_oranda-public.snap
+++ b/tests/snapshots/gal_oranda-public.snap
@@ -207,9 +207,9 @@ expression: "&snapshots"
             <h3>powershell</h3>
             <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+<span style="color:#82aaff;">irm https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex">
+  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -230,9 +230,9 @@ expression: "&snapshots"
             <h3>shell</h3>
             <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -373,7 +373,7 @@ expression: "&snapshots"
   </body>
 </html>
 ================ public/artifacts.json ================
-{"format_version":"CENSORED","tag":"v0.2.0","formatted_date":"Aug  8 2023 at 16:15 UTC","platforms_with_downloads":[{"target":["aarch64-apple-darwin"],"display_name":"macOS Apple Silicon","installers":[0,8,7,3]},{"target":["x86_64-apple-darwin"],"display_name":"macOS Intel","installers":[0,8,7,4]},{"target":["x86_64-pc-windows-msvc"],"display_name":"Windows x64","installers":[1,8,7,5]},{"target":["x86_64-unknown-linux-gnu"],"display_name":"Linux x64","installers":[0,8,7,6]}],"downloadable_files":[[1,{"name":"oranda-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":2},["macOS Apple Silicon"]],[7,{"name":"oranda-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":8},["macOS Intel"]],[9,{"name":"oranda-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":10},["Windows x64"]],[11,{"name":"oranda-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":12},["Linux x64"]]],"release":{"artifacts":{"files":[{"name":"dist-manifest.json","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/dist-manifest.json","view_path":null,"checksum_file":null},{"name":"oranda-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":2},{"name":"oranda-aarch64-apple-darwin.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz.sha256","view_path":null,"checksum_file":null},{"name":"oranda-config-schema.json","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-config-schema.json","view_path":null,"checksum_file":null},{"name":"oranda-installer.ps1","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.ps1","view_path":"oranda-installer.ps1.txt","checksum_file":null},{"name":"oranda-installer.sh","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh","view_path":"oranda-installer.sh.txt","checksum_file":null},{"name":"oranda-npm-package.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-npm-package.tar.gz","view_path":null,"checksum_file":null},{"name":"oranda-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":8},{"name":"oranda-x86_64-apple-darwin.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz.sha256","view_path":null,"checksum_file":null},{"name":"oranda-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":10},{"name":"oranda-x86_64-pc-windows-msvc.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz.sha256","view_path":null,"checksum_file":null},{"name":"oranda-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":12},{"name":"oranda-x86_64-unknown-linux-gnu.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz.sha256","view_path":null,"checksum_file":null}],"installers":[{"label":"shell","description":"Install prebuilt binaries via shell script","app_name":null,"method":{"type":"Run","file":5,"run_hint":"curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh"}},{"label":"powershell","description":"Install prebuilt binaries via powershell script","app_name":null,"method":{"type":"Run","file":4,"run_hint":"irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex"}},{"label":"npm","description":"Install prebuilt binaries into your npm project","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npm install @axodotdev/oranda@0.2.0"}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":1}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":7}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":9}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":11}},{"label":"npm","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npm install @axodotdev/oranda --save-dev"}},{"label":"cargo","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo install oranda --locked --profile=dist"}},{"label":"npx","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npx @axodotdev/oranda"}},{"label":"binstall","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo binstall oranda"}},{"label":"nix-env","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"nix-env -i oranda"}},{"label":"nix flake","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"nix profile install github:axodotdev/oranda"}}],"targets":{"aarch64-apple-darwin":[0,8,7,3],"aarch64-pc-windows-msvc":[8,7],"aarch64-unknown-linux-gnu":[8,7],"aarch64-unknown-linux-musl":[8,7],"i686-apple-darwin":[8,7],"i686-pc-windows-msvc":[8,7],"i686-unknown-linux-gnu":[8,7],"i686-unknown-linux-musl":[8,7],"x86_64-apple-darwin":[0,8,7,4],"x86_64-pc-windows-msvc":[1,8,7,5],"x86_64-unknown-linux-gnu":[0,8,7,6],"x86_64-unknown-linux-musl":[8,7]}}},"os_script":"/oranda/artifacts.js","has_checksum_files":true}
+{"format_version":"CENSORED","tag":"v0.2.0","formatted_date":"Aug  8 2023 at 16:15 UTC","platforms_with_downloads":[{"target":["aarch64-apple-darwin"],"display_name":"macOS Apple Silicon","installers":[12,6,5,1]},{"target":["x86_64-apple-darwin"],"display_name":"macOS Intel","installers":[12,6,5,2]},{"target":["x86_64-pc-windows-msvc"],"display_name":"Windows x64","installers":[11,6,5,3]},{"target":["x86_64-unknown-linux-gnu"],"display_name":"Linux x64","installers":[12,6,5,4]}],"downloadable_files":[[1,{"name":"oranda-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":2},["macOS Apple Silicon"]],[7,{"name":"oranda-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":8},["macOS Intel"]],[9,{"name":"oranda-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":10},["Windows x64"]],[11,{"name":"oranda-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":12},["Linux x64"]]],"release":{"artifacts":{"files":[{"name":"dist-manifest.json","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/dist-manifest.json","view_path":null,"checksum_file":null},{"name":"oranda-aarch64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz","view_path":null,"checksum_file":2},{"name":"oranda-aarch64-apple-darwin.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-aarch64-apple-darwin.tar.gz.sha256","view_path":null,"checksum_file":null},{"name":"oranda-config-schema.json","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-config-schema.json","view_path":null,"checksum_file":null},{"name":"oranda-installer.ps1","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.ps1","view_path":"oranda-installer.ps1.txt","checksum_file":null},{"name":"oranda-installer.sh","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh","view_path":"oranda-installer.sh.txt","checksum_file":null},{"name":"oranda-npm-package.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-npm-package.tar.gz","view_path":null,"checksum_file":null},{"name":"oranda-x86_64-apple-darwin.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz","view_path":null,"checksum_file":8},{"name":"oranda-x86_64-apple-darwin.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-apple-darwin.tar.gz.sha256","view_path":null,"checksum_file":null},{"name":"oranda-x86_64-pc-windows-msvc.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz","view_path":null,"checksum_file":10},{"name":"oranda-x86_64-pc-windows-msvc.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-pc-windows-msvc.tar.gz.sha256","view_path":null,"checksum_file":null},{"name":"oranda-x86_64-unknown-linux-gnu.tar.gz","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz","view_path":null,"checksum_file":12},{"name":"oranda-x86_64-unknown-linux-gnu.tar.gz.sha256","download_url":"https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-x86_64-unknown-linux-gnu.tar.gz.sha256","view_path":null,"checksum_file":null}],"installers":[{"label":"npm","description":"Install prebuilt binaries into your npm project","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npm install @axodotdev/oranda@0.2.0"}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":1}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":7}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":9}},{"label":"tarball","description":"","app_name":null,"method":{"type":"Download","file":11}},{"label":"npm","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npm install @axodotdev/oranda --save-dev"}},{"label":"cargo","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo install oranda --locked --profile=dist"}},{"label":"npx","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"npx @axodotdev/oranda"}},{"label":"binstall","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"cargo binstall oranda"}},{"label":"nix-env","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"nix-env -i oranda"}},{"label":"nix flake","description":"","app_name":null,"method":{"type":"Run","file":null,"run_hint":"nix profile install github:axodotdev/oranda"}},{"label":"powershell","description":"","app_name":null,"method":{"type":"Run","file":4,"run_hint":"irm https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex"}},{"label":"shell","description":"","app_name":null,"method":{"type":"Run","file":5,"run_hint":"curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh | sh"}}],"targets":{"aarch64-apple-darwin":[12,6,5,1],"aarch64-pc-windows-msvc":[11,6,5],"aarch64-unknown-linux-gnu":[12,6,5],"aarch64-unknown-linux-musl":[12,6,5],"i686-apple-darwin":[12,6,5],"i686-pc-windows-msvc":[11,6,5],"i686-unknown-linux-gnu":[12,6,5],"i686-unknown-linux-musl":[12,6,5],"x86_64-apple-darwin":[12,6,5,2],"x86_64-pc-windows-msvc":[11,6,5,3],"x86_64-unknown-linux-gnu":[12,6,5,4],"x86_64-unknown-linux-musl":[12,6,5]}}},"os_script":"/oranda/artifacts.js","has_checksum_files":true}
 ================ public/changelog/index.html ================
 <!DOCTYPE html>
 <html lang="en" id="oranda" class="dark axo">
@@ -1124,7 +1124,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="12" data-triple="aarch64-apple-darwin">
                   shell
 
                   
@@ -1132,7 +1132,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="8" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="6" data-triple="aarch64-apple-darwin">
                   cargo
 
                   
@@ -1140,7 +1140,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="5" data-triple="aarch64-apple-darwin">
                   npm
 
                   
@@ -1148,7 +1148,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="3" data-triple="aarch64-apple-darwin">
+                <li class="install-tab" data-id="1" data-triple="aarch64-apple-darwin">
                   tarball
 
                   
@@ -1160,14 +1160,14 @@ one that it <em>can't</em> parse.</p>
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="aarch64-apple-darwin" class="install-content">
+              <li data-id="12" data-triple="aarch64-apple-darwin" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -1185,7 +1185,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="8" data-triple="aarch64-apple-darwin" class="install-content hidden">
+              <li data-id="6" data-triple="aarch64-apple-darwin" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1204,7 +1204,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="7" data-triple="aarch64-apple-darwin" class="install-content hidden">
+              <li data-id="5" data-triple="aarch64-apple-darwin" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1223,7 +1223,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="3" data-triple="aarch64-apple-darwin" class="install-content hidden">
+              <li data-id="1" data-triple="aarch64-apple-darwin" class="install-content hidden">
                 
 
                 
@@ -1248,7 +1248,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="12" data-triple="x86_64-apple-darwin">
                   shell
 
                   
@@ -1256,7 +1256,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="8" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="6" data-triple="x86_64-apple-darwin">
                   cargo
 
                   
@@ -1264,7 +1264,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="5" data-triple="x86_64-apple-darwin">
                   npm
 
                   
@@ -1272,7 +1272,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="4" data-triple="x86_64-apple-darwin">
+                <li class="install-tab" data-id="2" data-triple="x86_64-apple-darwin">
                   tarball
 
                   
@@ -1284,14 +1284,14 @@ one that it <em>can't</em> parse.</p>
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="x86_64-apple-darwin" class="install-content">
+              <li data-id="12" data-triple="x86_64-apple-darwin" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -1309,7 +1309,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="8" data-triple="x86_64-apple-darwin" class="install-content hidden">
+              <li data-id="6" data-triple="x86_64-apple-darwin" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1328,7 +1328,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="7" data-triple="x86_64-apple-darwin" class="install-content hidden">
+              <li data-id="5" data-triple="x86_64-apple-darwin" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1347,7 +1347,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="4" data-triple="x86_64-apple-darwin" class="install-content hidden">
+              <li data-id="2" data-triple="x86_64-apple-darwin" class="install-content hidden">
                 
 
                 
@@ -1372,7 +1372,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="1" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="11" data-triple="x86_64-pc-windows-msvc">
                   powershell
 
                   
@@ -1380,7 +1380,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="8" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="6" data-triple="x86_64-pc-windows-msvc">
                   cargo
 
                   
@@ -1388,7 +1388,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="5" data-triple="x86_64-pc-windows-msvc">
                   npm
 
                   
@@ -1396,7 +1396,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="5" data-triple="x86_64-pc-windows-msvc">
+                <li class="install-tab" data-id="3" data-triple="x86_64-pc-windows-msvc">
                   tarball
 
                   
@@ -1408,14 +1408,14 @@ one that it <em>can't</em> parse.</p>
           <ul class="contents">
             
               
-              <li data-id="1" data-triple="x86_64-pc-windows-msvc" class="install-content">
+              <li data-id="11" data-triple="x86_64-pc-windows-msvc" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
+<span style="color:#82aaff;">irm https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.ps1 </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">iex</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex">
+  <button class="button copy-clipboard-button primary" data-copy="irm https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.ps1 | iex">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -1433,7 +1433,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="8" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+              <li data-id="6" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1452,7 +1452,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="7" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+              <li data-id="5" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1471,7 +1471,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="5" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
+              <li data-id="3" data-triple="x86_64-pc-windows-msvc" class="install-content hidden">
                 
 
                 
@@ -1496,7 +1496,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="0" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="12" data-triple="x86_64-unknown-linux-gnu">
                   shell
 
                   
@@ -1504,7 +1504,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="8" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="6" data-triple="x86_64-unknown-linux-gnu">
                   cargo
 
                   
@@ -1512,7 +1512,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="7" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="5" data-triple="x86_64-unknown-linux-gnu">
                   npm
 
                   
@@ -1520,7 +1520,7 @@ one that it <em>can't</em> parse.</p>
               
                 
                 
-                <li class="install-tab" data-id="6" data-triple="x86_64-unknown-linux-gnu">
+                <li class="install-tab" data-id="4" data-triple="x86_64-unknown-linux-gnu">
                   tarball
 
                   
@@ -1532,14 +1532,14 @@ one that it <em>can't</em> parse.</p>
           <ul class="contents">
             
               
-              <li data-id="0" data-triple="x86_64-unknown-linux-gnu" class="install-content">
+              <li data-id="12" data-triple="x86_64-unknown-linux-gnu" class="install-content">
                 
                   
                   <div class="install-code-wrapper">
   <pre style="background-color:#263238;">
-<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
+<span style="color:#82aaff;">curl</span><span style="color:#89ddff;"> --</span><span style="color:#f78c6c;">proto </span><span style="color:#89ddff;">&#39;</span><span style="color:#c3e88d;">=https</span><span style="color:#89ddff;">&#39; --</span><span style="color:#f78c6c;">tlsv1</span><span style="color:#82aaff;">.2</span><span style="color:#89ddff;"> -</span><span style="color:#f78c6c;">LsSf</span><span style="color:#82aaff;"> https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh </span><span style="color:#89ddff;">| </span><span style="color:#82aaff;">sh</span></pre>
 
-  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
+  <button class="button copy-clipboard-button primary" data-copy="curl --proto '=https' --tlsv1.2 -LsSf https://github.com/oranda-gallery/oranda/releases/download/v0.2.0/oranda-installer.sh | sh">
     <svg stroke='currentColor' fill='currentColor' stroke-width='0' viewBox='0 0 20 20' height='1em' width='1em' xmlns='http://www.w3.org/2000/svg'><path d='M8 2a1 1 0 000 2h2a1 1 0 100-2H8z'></path><path d='M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z'></path></svg>
   </button>
   
@@ -1557,7 +1557,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="8" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+              <li data-id="6" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1576,7 +1576,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="7" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+              <li data-id="5" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
                 
                   
                   <div class="install-code-wrapper">
@@ -1595,7 +1595,7 @@ one that it <em>can't</em> parse.</p>
               </li>
             
               
-              <li data-id="6" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
+              <li data-id="4" data-triple="x86_64-unknown-linux-gnu" class="install-content hidden">
                 
 
                 


### PR DESCRIPTION
The dist-manifest.json fundamentally lacks the information to generate perfect pretty curl-sh exprs, because it needs to be uploaded before the create-release endpoint tells us this url format. As such, oranda should ignore the manifest for these install-hints, and instead use the inference backend for them, which can use the URLs returned by the list-releases endpoint (or the github release's base url).