### PR TITLE
fix: Remove project-root and config-path from documentation

### DIFF
--- a/docs/src/cli/build.md
+++ b/docs/src/cli/build.md
@@ -1,9 +1,4 @@
 # `oranda build`
 
-This command builds your oranda site. You can specify:
-
-- **The project root** (`--project-root`), in case you want to build from another directory
-- **The config path** (`--config-path`), if your configuration file is not `./oranda.json`
-
-You can also pass the `--json-only` flag in order for oranda to _only_ build an `artifacts.json` file that can
+This command builds your oranda site. You can specify the `--json-only` flag in order for oranda to _only_ build an `artifacts.json` file that can
 be read by other tools (or websites) for integration purposes.

--- a/docs/src/cli/build.md
+++ b/docs/src/cli/build.md
@@ -1,4 +1,6 @@
 # `oranda build`
 
-This command builds your oranda site. You can specify the `--json-only` flag in order for oranda to _only_ build an `artifacts.json` file that can
-be read by other tools (or websites) for integration purposes.
+This command builds your oranda site. You can pass the `--json-only` flag in order for oranda to _only_ build an
+`artifacts.json` file that can be read by other tools (or websites) for integration purposes. You can also specify
+`--config-path` if your configuration file is not `./oranda.json`, but oranda will still look for an
+`oranda-workspace.json` in the current directory.

--- a/docs/src/cli/dev.md
+++ b/docs/src/cli/dev.md
@@ -20,7 +20,5 @@ such, we have to take care to only run the build process when _relevant_ files c
 This command also supports several options:
 
 - `--port` to set a custom port for the file server
-- `--project-root` to change the root directory from where your site will be built
-- `--config-path` to specify a custom path for your oranda config
 - `--no-first-build` to skip the first step mentioned above where oranda builds your site before starting the watch process
 - `-i`, `--include-paths` to specify custom paths for oranda to watch

--- a/docs/src/cli/dev.md
+++ b/docs/src/cli/dev.md
@@ -20,5 +20,6 @@ such, we have to take care to only run the build process when _relevant_ files c
 This command also supports several options:
 
 - `--port` to set a custom port for the file server
+- `--config-path` to specify a custom path for your oranda config (but oranda will still look for an `oranda-workspace.json`) in your current directory).
 - `--no-first-build` to skip the first step mentioned above where oranda builds your site before starting the watch process
 - `-i`, `--include-paths` to specify custom paths for oranda to watch


### PR DESCRIPTION
For issue https://github.com/axodotdev/oranda/issues/683, where `--project-root` and `--config-path` is described in documentation but doesn't work.

This changes the docs, not the code!