### PR TITLE
fix: linkcheck plugin on *nix

### DIFF
--- a/src/site/mdbook.rs
+++ b/src/site/mdbook.rs
@@ -275,8 +275,10 @@ pub fn build_mdbook(
 ///
 /// Interesting things only happen when you run `.build()`
 pub fn load_mdbook(book_dir: &Utf8Path) -> Result<MDBook> {
-    let md = MDBook::load(book_dir).map_err(|e| OrandaError::MdBookLoad {
-        path: book_dir.to_string(),
+    // An absolute path is necessary for plugins such as linkcheck to work.
+    let path = book_dir.canonicalize_utf8().unwrap_or(book_dir.to_owned());
+    let md = MDBook::load(&path).map_err(|e| OrandaError::MdBookLoad {
+        path: path.to_string(),
         details: e,
     })?;
 


### PR DESCRIPTION
On Linux and macOS, trying to run with the linkcheck plugin configured would error out with the following error:

```
Error: Unable to resolve the source directory

Caused by:
    No such file or directory (os error 2)
  × Couldn't build your mdbook at book
  ├─▶ Rendering failed
  ╰─▶ The "linkcheck" renderer failed
  ```

This turns out to have been caused by us passing a relative path to the book directory instead of an absolute path. The relative path was fine for the main rendering process, but not the linkcheck plugin.

It appears that we intentionally made the path relative before passing it in here, but I'm not clear on why. It makes more sense in some of the "watching paths" route, but this path clearly works *better* as an absolute path. If we're happy with going with the absolute path, it probably makes sense to just join `book_path` to `root_path` instead of going through `paths::determine_path()`.